### PR TITLE
[backend] [pr1] packet decoder

### DIFF
--- a/backend/pkg/transport/packet/data.go
+++ b/backend/pkg/transport/packet/data.go
@@ -1,0 +1,31 @@
+package packet
+
+import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+
+type DataDescriptor []ValueDescriptor
+
+var _ abstraction.Packet = &Data{}
+
+type Data struct {
+	id     abstraction.PacketId
+	values map[ValueName]Value
+}
+
+func NewData(id abstraction.PacketId) *Data {
+	return &Data{
+		id:     id,
+		values: make(map[ValueName]Value),
+	}
+}
+
+func (data *Data) Id() abstraction.PacketId {
+	return data.id
+}
+
+func (data *Data) SetValue(name ValueName, value Value) {
+	data.values[name] = value
+}
+
+func (data *Data) GetValues() map[ValueName]Value {
+	return data.values
+}

--- a/backend/pkg/transport/packet/data.go
+++ b/backend/pkg/transport/packet/data.go
@@ -2,15 +2,19 @@ package packet
 
 import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 
+// DataDescriptor describes the structure of a data packet as an array of values
 type DataDescriptor []ValueDescriptor
 
+// Type assertion to check Data follows the abstraction.Packet interface
 var _ abstraction.Packet = &Data{}
 
+// Data is a data packet containing multiple values
 type Data struct {
 	id     abstraction.PacketId
 	values map[ValueName]Value
 }
 
+// NewData creates a new data packet
 func NewData(id abstraction.PacketId) *Data {
 	return &Data{
 		id:     id,
@@ -18,14 +22,17 @@ func NewData(id abstraction.PacketId) *Data {
 	}
 }
 
+// Id returns the id of the data packet
 func (data *Data) Id() abstraction.PacketId {
 	return data.id
 }
 
+// SetValue updates the value with the given name to the new value. It overwrites a value if it is already set
 func (data *Data) SetValue(name ValueName, value Value) {
 	data.values[name] = value
 }
 
+// GetValues returns all values associated with the packet
 func (data *Data) GetValues() map[ValueName]Value {
 	return data.values
 }

--- a/backend/pkg/transport/packet/value.go
+++ b/backend/pkg/transport/packet/value.go
@@ -1,0 +1,109 @@
+package packet
+
+import "reflect"
+
+type ValueType string
+
+const (
+	Uint8Type   ValueType = "uint8"
+	Uint16Type  ValueType = "uint16"
+	Uint32Type  ValueType = "uint32"
+	Uint64Type  ValueType = "uint64"
+	Int8Type    ValueType = "int8"
+	Int16Type   ValueType = "int16"
+	Int32Type   ValueType = "int32"
+	Int64Type   ValueType = "int64"
+	Float32Type ValueType = "float32"
+	Float64Type ValueType = "float64"
+	BoolType    ValueType = "bool"
+	EnumType    ValueType = "enum"
+)
+
+type ValueName string
+
+type ValueDescriptor struct {
+	Name ValueName
+	Type ValueType
+}
+
+type Value interface {
+	Type() ValueType
+}
+
+// Maybe this is not the best place to put this in
+type numeric interface {
+	uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | float32 | float64
+}
+
+var _ Value = NumericValue[uint8]{}
+var _ Value = NumericValue[uint16]{}
+var _ Value = NumericValue[uint32]{}
+var _ Value = NumericValue[uint64]{}
+var _ Value = NumericValue[int8]{}
+var _ Value = NumericValue[int16]{}
+var _ Value = NumericValue[int32]{}
+var _ Value = NumericValue[int64]{}
+var _ Value = NumericValue[float32]{}
+var _ Value = NumericValue[float64]{}
+
+type NumericValue[N numeric] struct {
+	inner N
+}
+
+func NewNumericValue[N numeric](val N) NumericValue[N] {
+	return NumericValue[N]{
+		inner: val,
+	}
+}
+
+func (value NumericValue[N]) Value() float64 {
+	return float64(value.inner)
+}
+
+func (value NumericValue[N]) Type() ValueType {
+	return ValueType(reflect.TypeOf(value.inner).Name())
+}
+
+var _ Value = BooleanValue{}
+
+type BooleanValue struct {
+	inner bool
+}
+
+func NewBooleanValue(val bool) BooleanValue {
+	return BooleanValue{
+		inner: val,
+	}
+}
+
+func (value BooleanValue) Value() bool {
+	return value.inner
+}
+
+func (value BooleanValue) Type() ValueType {
+	return BoolType
+}
+
+type EnumVariant string
+
+type EnumDescriptor []EnumVariant
+
+var _ Value = EnumValue{}
+
+type EnumValue struct {
+	inner EnumVariant
+}
+
+func NewEnumValue(val EnumVariant) EnumValue {
+	return EnumValue{
+		inner: val,
+	}
+}
+
+func (value EnumValue) Variant() EnumVariant {
+	return value.inner
+}
+
+func (value EnumValue) Type() ValueType {
+	return EnumType
+}

--- a/backend/pkg/transport/packet/value.go
+++ b/backend/pkg/transport/packet/value.go
@@ -2,6 +2,7 @@ package packet
 
 import "reflect"
 
+// ValueType is the variable type of a data packet value
 type ValueType string
 
 const (
@@ -19,22 +20,26 @@ const (
 	EnumType    ValueType = "enum"
 )
 
+// ValueName is the name of the value
 type ValueName string
 
+// ValueDescriptor describes a value of a packet
 type ValueDescriptor struct {
 	Name ValueName
 	Type ValueType
 }
 
+// Value is an interface over all kinds of values
 type Value interface {
 	Type() ValueType
 }
 
-// Maybe this is not the best place to put this in
+// numeric is a helper interface to group any kind of numeric variable
 type numeric interface {
 	uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | float32 | float64
 }
 
+// type assertions to check numeric values follow the Value interface
 var _ Value = NumericValue[uint8]{}
 var _ Value = NumericValue[uint16]{}
 var _ Value = NumericValue[uint32]{}
@@ -46,64 +51,80 @@ var _ Value = NumericValue[int64]{}
 var _ Value = NumericValue[float32]{}
 var _ Value = NumericValue[float64]{}
 
+// NumericValue is a value holding a number
 type NumericValue[N numeric] struct {
 	inner N
 }
 
+// NewNumericValue creates a new numeric value
 func NewNumericValue[N numeric](val N) NumericValue[N] {
 	return NumericValue[N]{
 		inner: val,
 	}
 }
 
+// Value returns the associated number, always as float64
 func (value NumericValue[N]) Value() float64 {
 	return float64(value.inner)
 }
 
+// Type returns the type of the numeric value
 func (value NumericValue[N]) Type() ValueType {
 	return ValueType(reflect.TypeOf(value.inner).Name())
 }
 
+// type assertion to check BooleanValue follows the Value interface
 var _ Value = BooleanValue{}
 
+// BooleanValue is a value holding a bool
 type BooleanValue struct {
 	inner bool
 }
 
+// NewBooleanValue creates a new boolean value
 func NewBooleanValue(val bool) BooleanValue {
 	return BooleanValue{
 		inner: val,
 	}
 }
 
+// Value returns the associated value
 func (value BooleanValue) Value() bool {
 	return value.inner
 }
 
+// Type returns the type of the boolean value
 func (value BooleanValue) Type() ValueType {
 	return BoolType
 }
 
+// EnumVariant is one of the variants an enum can have
 type EnumVariant string
 
+// EnumDescriptor describes the possible variants an enum might have
 type EnumDescriptor []EnumVariant
 
+// type assertion to check EnumValue follows the Value interface
 var _ Value = EnumValue{}
 
+// EnumValue is a value holding the variant of an enum
 type EnumValue struct {
 	inner EnumVariant
 }
 
+// NewEnumValue creates a new enum value
 func NewEnumValue(val EnumVariant) EnumValue {
 	return EnumValue{
 		inner: val,
 	}
 }
 
+// Variant returns the variant of this value
 func (value EnumValue) Variant() EnumVariant {
 	return value.inner
 }
 
+// Type returns the type of the enum value
 func (value EnumValue) Type() ValueType {
 	return EnumType
 }

--- a/backend/pkg/transport/presentation/decoder.go
+++ b/backend/pkg/transport/presentation/decoder.go
@@ -1,3 +1,0 @@
-package presentation
-
-type PacketDecoder struct{}

--- a/backend/pkg/transport/presentation/decoder/data.go
+++ b/backend/pkg/transport/presentation/decoder/data.go
@@ -1,0 +1,94 @@
+package decoder
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
+)
+
+type valueDecoder func(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error)
+
+type Data struct {
+	endianness       binary.ByteOrder
+	idToDescription  map[abstraction.PacketId]packet.DataDescriptor
+	enumDescriptions map[packet.ValueName]packet.EnumDescriptor
+	valueDecoders    map[packet.ValueType]valueDecoder
+}
+
+func (decoder *Data) Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error) {
+	descriptor, ok := decoder.idToDescription[id]
+	if !ok {
+		return nil, presentation.ErrUnexpectedId{Id: id}
+	}
+
+	packet := packet.NewData(id)
+	for _, value := range descriptor {
+		dec, ok := decoder.valueDecoders[value.Type]
+		if !ok {
+			return packet, presentation.ErrUnexpectedValue{Value: value}
+		}
+
+		val, err := dec(value.Name, decoder.endianness, reader)
+		if err != nil {
+			return packet, err
+		}
+		packet.SetValue(value.Name, val)
+	}
+
+	return packet, nil
+}
+
+type numeric interface {
+	uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | float32 | float64
+}
+
+var _ valueDecoder = decodeNumeric[uint8]
+var _ valueDecoder = decodeNumeric[uint16]
+var _ valueDecoder = decodeNumeric[uint32]
+var _ valueDecoder = decodeNumeric[uint64]
+var _ valueDecoder = decodeNumeric[int8]
+var _ valueDecoder = decodeNumeric[int16]
+var _ valueDecoder = decodeNumeric[int32]
+var _ valueDecoder = decodeNumeric[int64]
+var _ valueDecoder = decodeNumeric[float32]
+var _ valueDecoder = decodeNumeric[float64]
+
+func decodeNumeric[N numeric](name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
+	var val N
+	err := binary.Read(reader, endianness, &val)
+	return packet.NewNumericValue[N](val), err
+}
+
+var _ valueDecoder = decodeBool
+
+func decodeBool(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
+	var val bool
+	err := binary.Read(reader, endianness, &val)
+	return packet.NewBooleanValue(val), err
+}
+
+var _ valueDecoder = (&Data{}).decodeEnum
+
+func (decoder *Data) decodeEnum(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
+	enum, ok := decoder.enumDescriptions[name]
+	if !ok {
+		return nil, presentation.ErrUndefinedEnum{Name: name}
+	}
+
+	var val uint8
+	err := binary.Read(reader, endianness, &val)
+	if err != nil {
+		return nil, err
+	}
+	idx := int(val)
+
+	if idx >= len(enum) {
+		return nil, presentation.ErrInvalidVariant{Idx: idx, Len: len(enum)}
+	}
+
+	return packet.NewEnumValue(enum[idx]), nil
+
+}

--- a/backend/pkg/transport/presentation/decoder/data.go
+++ b/backend/pkg/transport/presentation/decoder/data.go
@@ -11,14 +11,16 @@ import (
 
 type valueDecoder func(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error)
 
-type Data struct {
+var _ Decoder = &data{}
+
+type data struct {
 	endianness       binary.ByteOrder
 	idToDescription  map[abstraction.PacketId]packet.DataDescriptor
 	enumDescriptions map[packet.ValueName]packet.EnumDescriptor
 	valueDecoders    map[packet.ValueType]valueDecoder
 }
 
-func (decoder *Data) Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error) {
+func (decoder *data) Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error) {
 	descriptor, ok := decoder.idToDescription[id]
 	if !ok {
 		return nil, presentation.ErrUnexpectedId{Id: id}
@@ -70,9 +72,9 @@ func decodeBool(name packet.ValueName, endianness binary.ByteOrder, reader io.Re
 	return packet.NewBooleanValue(val), err
 }
 
-var _ valueDecoder = (&Data{}).decodeEnum
+var _ valueDecoder = (&data{}).decodeEnum
 
-func (decoder *Data) decodeEnum(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
+func (decoder *data) decodeEnum(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
 	enum, ok := decoder.enumDescriptions[name]
 	if !ok {
 		return nil, presentation.ErrUndefinedEnum{Name: name}

--- a/backend/pkg/transport/presentation/decoder/data.go
+++ b/backend/pkg/transport/presentation/decoder/data.go
@@ -9,10 +9,14 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
 )
 
+// valueDecoder is a function that tells how a value should be decoded based on its type
 type valueDecoder func(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error)
 
+// Type assertion to check data follows the Decoder interface
 var _ Decoder = &data{}
 
+// data is a decoder for packets using the standard encoding. These packets are defined externally and their definitions
+// are given beforehand. With these structures the packets can be decoded correctly.
 type data struct {
 	endianness       binary.ByteOrder
 	idToDescription  map[abstraction.PacketId]packet.DataDescriptor
@@ -20,6 +24,9 @@ type data struct {
 	valueDecoders    map[packet.ValueType]valueDecoder
 }
 
+// Decode decodes the next packet for the given id
+//
+// the value decoders should be set before calling this method
 func (decoder *data) Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error) {
 	descriptor, ok := decoder.idToDescription[id]
 	if !ok {
@@ -43,10 +50,12 @@ func (decoder *data) Decode(id abstraction.PacketId, reader io.Reader) (abstract
 	return packet, nil
 }
 
+// numeric represents any numeric variable
 type numeric interface {
 	uint8 | uint16 | uint32 | uint64 | int8 | int16 | int32 | int64 | float32 | float64
 }
 
+// type assertions to check all variants of decodeNumeric are valueDecoders
 var _ valueDecoder = decodeNumeric[uint8]
 var _ valueDecoder = decodeNumeric[uint16]
 var _ valueDecoder = decodeNumeric[uint32]
@@ -58,22 +67,29 @@ var _ valueDecoder = decodeNumeric[int64]
 var _ valueDecoder = decodeNumeric[float32]
 var _ valueDecoder = decodeNumeric[float64]
 
+// decodeNumeric decodes the next numeric value based on the provided type
 func decodeNumeric[N numeric](name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
 	var val N
 	err := binary.Read(reader, endianness, &val)
 	return packet.NewNumericValue[N](val), err
 }
 
+// type assertion to check decodeBool follows valueDecoder
 var _ valueDecoder = decodeBool
 
+// decodeBool decodes the next boolean value
 func decodeBool(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
 	var val bool
 	err := binary.Read(reader, endianness, &val)
 	return packet.NewBooleanValue(val), err
 }
 
+// type assertion to check decodeEnum follows valueDecoder
 var _ valueDecoder = (&data{}).decodeEnum
 
+// decodeEnum decodes the next incoming enum
+//
+// it is a method of data because the extra information needed to find the enum variant based on the value
 func (decoder *data) decodeEnum(name packet.ValueName, endianness binary.ByteOrder, reader io.Reader) (packet.Value, error) {
 	enum, ok := decoder.enumDescriptions[name]
 	if !ok {

--- a/backend/pkg/transport/presentation/decoder/decoder.go
+++ b/backend/pkg/transport/presentation/decoder/decoder.go
@@ -12,12 +12,12 @@ type Decoder interface {
 	Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error)
 }
 
-type PacketDecoder struct {
+type Packet struct {
 	idToDecoder map[abstraction.PacketId]Decoder
 	endianness  binary.ByteOrder
 }
 
-func (decoder *PacketDecoder) DecodeNext(reader io.Reader) (abstraction.Packet, error) {
+func (decoder *Packet) DecodeNext(reader io.Reader) (abstraction.Packet, error) {
 	var id abstraction.PacketId
 	err := binary.Read(reader, decoder.endianness, &id)
 	if err != nil {

--- a/backend/pkg/transport/presentation/decoder/decoder.go
+++ b/backend/pkg/transport/presentation/decoder/decoder.go
@@ -8,15 +8,18 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
 )
 
+// Decoder is a common interface for packet-specific decoders
 type Decoder interface {
 	Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error)
 }
 
+// Packet is the root decoder, it takes the id of the packet and decodes the rest of it
 type Packet struct {
 	idToDecoder map[abstraction.PacketId]Decoder
 	endianness  binary.ByteOrder
 }
 
+// DecodeNext reads and decodes the next packet from the input stream, returning any errors encountered
 func (decoder *Packet) DecodeNext(reader io.Reader) (abstraction.Packet, error) {
 	var id abstraction.PacketId
 	err := binary.Read(reader, decoder.endianness, &id)

--- a/backend/pkg/transport/presentation/decoder/decoder.go
+++ b/backend/pkg/transport/presentation/decoder/decoder.go
@@ -1,0 +1,49 @@
+package decoder
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
+)
+
+type Decoder interface {
+	Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error)
+}
+
+type packetCallback = func(abstraction.Packet)
+
+type PacketDecoder struct {
+	idToDecoder map[abstraction.PacketId]Decoder
+	onPacket    packetCallback
+	endianness  binary.ByteOrder
+}
+
+func (decoder *PacketDecoder) DecodeFrom(reader io.Reader) error {
+	var id abstraction.PacketId
+	idBuf := make([]byte, binary.Size(id))
+	n, err := reader.Read(idBuf)
+	if n < 2 {
+		return io.ErrUnexpectedEOF
+	}
+
+	id = abstraction.PacketId(decoder.endianness.Uint16(idBuf[:n]))
+
+	if err != nil {
+		return err
+	}
+
+	dec, ok := decoder.idToDecoder[id]
+	if !ok {
+		return presentation.ErrUnexpectedId{Id: id}
+	}
+
+	packet, err := dec.Decode(id, reader)
+	if err != nil {
+		return err
+	}
+
+	decoder.onPacket(packet)
+	return nil
+}

--- a/backend/pkg/transport/presentation/errors.go
+++ b/backend/pkg/transport/presentation/errors.go
@@ -1,0 +1,15 @@
+package presentation
+
+import (
+	"fmt"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type ErrUnexpectedId struct {
+	Id abstraction.PacketId
+}
+
+func (err ErrUnexpectedId) Error() string {
+	return fmt.Sprintf("unexpected id %d", err.Id)
+}

--- a/backend/pkg/transport/presentation/errors.go
+++ b/backend/pkg/transport/presentation/errors.go
@@ -7,6 +7,7 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet"
 )
 
+// ErrUnexpectedId is returned when an ID is not recognized or is not defined
 type ErrUnexpectedId struct {
 	Id abstraction.PacketId
 }
@@ -15,6 +16,7 @@ func (err ErrUnexpectedId) Error() string {
 	return fmt.Sprintf("unexpected id %d", err.Id)
 }
 
+// ErrUnexpectedValue is returned when a codec is not found for a value
 type ErrUnexpectedValue struct {
 	Value packet.ValueDescriptor
 }
@@ -23,6 +25,7 @@ func (err ErrUnexpectedValue) Error() string {
 	return fmt.Sprintf("unexpected value %s with type %s", err.Value.Name, err.Value.Type)
 }
 
+// ErrUndefinedEnum is returned when an enum is not defined
 type ErrUndefinedEnum struct {
 	Name packet.ValueName
 }
@@ -31,6 +34,7 @@ func (err ErrUndefinedEnum) Error() string {
 	return fmt.Sprintf("enum %s is not defined", err.Name)
 }
 
+// ErrInvalidVariant is returned when trying to access an invalid enum variant
 type ErrInvalidVariant struct {
 	Name packet.ValueName
 	Idx  int

--- a/backend/pkg/transport/presentation/errors.go
+++ b/backend/pkg/transport/presentation/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet"
 )
 
 type ErrUnexpectedId struct {
@@ -12,4 +13,30 @@ type ErrUnexpectedId struct {
 
 func (err ErrUnexpectedId) Error() string {
 	return fmt.Sprintf("unexpected id %d", err.Id)
+}
+
+type ErrUnexpectedValue struct {
+	Value packet.ValueDescriptor
+}
+
+func (err ErrUnexpectedValue) Error() string {
+	return fmt.Sprintf("unexpected value %s with type %s", err.Value.Name, err.Value.Type)
+}
+
+type ErrUndefinedEnum struct {
+	Name packet.ValueName
+}
+
+func (err ErrUndefinedEnum) Error() string {
+	return fmt.Sprintf("enum %s is not defined", err.Name)
+}
+
+type ErrInvalidVariant struct {
+	Name packet.ValueName
+	Idx  int
+	Len  int
+}
+
+func (err ErrInvalidVariant) Error() string {
+	return fmt.Sprintf("enum %s has %d variants, but tried to access the %d variant", err.Name, err.Len, err.Idx+1)
 }

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -6,6 +6,7 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/tcp"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/tftp"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation/decoder"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/session"
 )
 
@@ -16,7 +17,7 @@ import (
 // or notification has an associated event which is used to determine the
 // action to take.
 type Transport struct {
-	decoder *presentation.PacketDecoder
+	decoder *decoder.PacketDecoder
 	encoder *presentation.PacketEncoder
 
 	snifferDemux *session.SnifferDemux

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -17,7 +17,7 @@ import (
 // or notification has an associated event which is used to determine the
 // action to take.
 type Transport struct {
-	decoder *decoder.PacketDecoder
+	decoder *decoder.Packet
 	encoder *presentation.PacketEncoder
 
 	snifferDemux *session.SnifferDemux


### PR DESCRIPTION
The `decoder` takes all incoming communications and turns the raw binary into concrete go structs.

This first PR covers the root decoder, `Packet` and the data decoder `data`. 

The root decoder reads the id of the packet and chooses the appropriate decoder to keep decoding the message.

The data decoder decodes packets based on the structure defined on the ADE.