### PR TITLE
[backend] [pr2] protection decoder

### DIFF
--- a/backend/pkg/transport/packet/protection/decoder.go
+++ b/backend/pkg/transport/packet/protection/decoder.go
@@ -1,0 +1,67 @@
+package protection
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type protectionAdapter struct {
+	Name ProtectionName   `json:"name"`
+	Type kind             `json:"type"`
+	Data *json.RawMessage `json:"data"`
+}
+
+func (protection *Protection) UnmarshalJSON(data []byte) error {
+	var adapter protectionAdapter
+	err := json.Unmarshal(data, &adapter)
+	if err != nil {
+		return err
+	}
+
+	protection.Name = adapter.Name
+	protection.Type = adapter.Type
+
+	switch adapter.Type {
+	case OutOfBoundsKind:
+		protection.Data = new(OutOfBounds)
+	case UpperBoundKind:
+		protection.Data = new(UpperBound)
+	case LowerBoundKind:
+		protection.Data = new(LowerBound)
+	case EqualsKind:
+		protection.Data = new(Equals)
+	case NotEqualsKind:
+		protection.Data = new(NotEquals)
+	case TimeAccumulationKind:
+		protection.Data = new(TimeAccumulation)
+	case ErrorHandlerKind:
+		protection.Data = new(ErrorHandler)
+	default:
+		return ErrUnknownKind{Kind: adapter.Type}
+	}
+
+	return json.Unmarshal(*adapter.Data, &protection.Data)
+}
+
+type Decoder struct {
+	idToSeverity map[abstraction.PacketId]severity
+}
+
+func (decoder *Decoder) Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error) {
+	severity, ok := decoder.idToSeverity[id]
+	if !ok {
+		return nil, ErrUnknownSeverity{Id: id}
+	}
+
+	packet := Packet{
+		id:       id,
+		severity: severity,
+	}
+
+	jsonDecoder := json.NewDecoder(reader)
+
+	err := jsonDecoder.Decode(&packet)
+	return &packet, err
+}

--- a/backend/pkg/transport/packet/protection/errors.go
+++ b/backend/pkg/transport/packet/protection/errors.go
@@ -1,0 +1,23 @@
+package protection
+
+import (
+	"fmt"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type ErrUnknownKind struct {
+	Kind kind
+}
+
+func (err ErrUnknownKind) Error() string {
+	return fmt.Sprintf("unrecognized kind %s", err.Kind)
+}
+
+type ErrUnknownSeverity struct {
+	Id abstraction.PacketId
+}
+
+func (err ErrUnknownSeverity) Error() string {
+	return fmt.Sprintf("unknown severity for id %d", err.Id)
+}

--- a/backend/pkg/transport/packet/protection/kind.go
+++ b/backend/pkg/transport/packet/protection/kind.go
@@ -1,0 +1,77 @@
+package protection
+
+type kind string
+
+type Protection interface {
+	Kind() kind
+}
+
+const (
+	OutOfBoundsKind      kind = "OUT_OF_BOUNDS"
+	LowerBoundKind       kind = "LOWER_BOUND"
+	UpperBoundKind       kind = "UPPER_BOUND"
+	EqualsKind           kind = "EQUALS"
+	NotEqualsKind        kind = "NOT_EQUALS"
+	TimeAccumulationKind kind = "TIME_ACCUMULATION"
+	ErrorHandlerKind     kind = "ERROR_HANDLER"
+)
+
+type OutOfBounds struct {
+	Value  float64    `json:"value"`
+	Bounds [2]float64 `json:"bounds"`
+}
+
+func (protection *OutOfBounds) Kind() kind {
+	return OutOfBoundsKind
+}
+
+type UpperBound struct {
+	Value float64 `json:"value"`
+	Bound float64 `json:"bound"`
+}
+
+func (protection *UpperBound) Kind() kind {
+	return UpperBoundKind
+}
+
+type LowerBound struct {
+	Value float64 `json:"value"`
+	Bound float64 `json:"bound"`
+}
+
+func (protection *LowerBound) Kind() kind {
+	return LowerBoundKind
+}
+
+type Equals struct {
+	Value float64 `json:"value"`
+}
+
+func (protection *Equals) Kind() kind {
+	return EqualsKind
+}
+
+type NotEquals struct {
+	Value float64 `json:"value"`
+	Want  float64 `json:"want"`
+}
+
+func (protection *NotEquals) Kind() kind {
+	return NotEqualsKind
+}
+
+type TimeAccumulation struct {
+	Value     float64 `json:"value"`
+	Bound     float64 `json:"bound"`
+	TimeLimit float64 `json:"timelimit"`
+}
+
+func (protection *TimeAccumulation) Kind() kind {
+	return TimeAccumulationKind
+}
+
+type ErrorHandler string
+
+func (protection *ErrorHandler) Kind() kind {
+	return ErrorHandlerKind
+}

--- a/backend/pkg/transport/packet/protection/kind.go
+++ b/backend/pkg/transport/packet/protection/kind.go
@@ -1,8 +1,17 @@
 package protection
 
+type severity string
+
+const (
+	SeverityInfo    severity = "info"
+	SeverityWarning severity = "warning"
+	SeverityFault   severity = "fault"
+	SeverityError   severity = "error"
+)
+
 type kind string
 
-type Protection interface {
+type ProtectionData interface {
 	Kind() kind
 }
 

--- a/backend/pkg/transport/packet/protection/packet.go
+++ b/backend/pkg/transport/packet/protection/packet.go
@@ -1,6 +1,8 @@
 package protection
 
-import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+import (
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
 
 type Timestamp struct {
 	Counter uint16 `json:"counter"`
@@ -13,7 +15,25 @@ type Timestamp struct {
 }
 
 type Packet struct {
+	id         abstraction.PacketId
 	BoardId    abstraction.BoardId `json:"boardId"`
 	Timestamp  Timestamp           `json:"timestamp"`
 	Protection Protection          `json:"protection"`
+	severity   severity
+}
+
+func (packet *Packet) Severity() severity {
+	return packet.severity
+}
+
+func (packet *Packet) Id() abstraction.PacketId {
+	return packet.id
+}
+
+type ProtectionName string
+
+type Protection struct {
+	Name ProtectionName `json:"name"`
+	Type kind           `json:"type"`
+	Data ProtectionData `json:"data"`
 }

--- a/backend/pkg/transport/packet/protection/packet.go
+++ b/backend/pkg/transport/packet/protection/packet.go
@@ -1,0 +1,19 @@
+package protection
+
+import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+
+type Timestamp struct {
+	Counter uint16 `json:"counter"`
+	Second  uint8  `json:"second"`
+	Minute  uint8  `json:"minute"`
+	Hour    uint8  `json:"hour"`
+	Day     uint8  `json:"day"`
+	Month   uint8  `json:"month"`
+	Year    uint16 `json:"year"`
+}
+
+type Packet struct {
+	BoardId    abstraction.BoardId `json:"boardId"`
+	Timestamp  Timestamp           `json:"timestamp"`
+	Protection Protection          `json:"protection"`
+}


### PR DESCRIPTION
The protection messages are currently encoded as JSON, although they will later on have their own encoding similar to other packets to reduce load and bandwidth usage.

This PR implements the protection message decoding. It defines the protection model and provides functions to decode the json stream.