### PR TITLE
[backend] packet encoder

### DIFF
--- a/backend/pkg/transport/packet/data/codec.go
+++ b/backend/pkg/transport/packet/data/codec.go
@@ -8,6 +8,9 @@ import (
 // valueDecoder is a function that tells how a value should be decoded based on its type
 type valueDecoder func(endianness binary.ByteOrder, reader io.Reader) (Value, error)
 
+// valueEncoder is a function that tells how a value should be encoded based on its type
+type valueEncoder func(endianness binary.ByteOrder, value Value, writer io.Writer) error
+
 // type assertions to check all variants of decodeNumeric are valueDecoders
 var _ valueDecoder = decodeNumeric[uint8]
 var _ valueDecoder = decodeNumeric[uint16]
@@ -27,6 +30,27 @@ func decodeNumeric[N numeric](endianness binary.ByteOrder, reader io.Reader) (Va
 	return NewNumericValue[N](val), err
 }
 
+// type assertions to check all variants of encodeNumeric are valueEncoders
+var _ valueEncoder = encodeNumeric[uint8]
+var _ valueEncoder = encodeNumeric[uint16]
+var _ valueEncoder = encodeNumeric[uint32]
+var _ valueEncoder = encodeNumeric[uint64]
+var _ valueEncoder = encodeNumeric[int8]
+var _ valueEncoder = encodeNumeric[int16]
+var _ valueEncoder = encodeNumeric[int32]
+var _ valueEncoder = encodeNumeric[int64]
+var _ valueEncoder = encodeNumeric[float32]
+var _ valueEncoder = encodeNumeric[float64]
+
+// encodeNumeric encodes the numeric value into the provided writer
+func encodeNumeric[N numeric](endianness binary.ByteOrder, value Value, writer io.Writer) error {
+	num, ok := value.(NumericValue[N])
+	if !ok {
+		return ErrMismatchedTypes{Value: value}
+	}
+	return binary.Write(writer, endianness, num.inner)
+}
+
 // type assertion to check decodeBool follows valueDecoder
 var _ valueDecoder = decodeBool
 
@@ -35,6 +59,18 @@ func decodeBool(endianness binary.ByteOrder, reader io.Reader) (Value, error) {
 	var val bool
 	err := binary.Read(reader, endianness, &val)
 	return NewBooleanValue(val), err
+}
+
+// type assertion to check encodeBool follows valueEncoder
+var _ valueEncoder = encodeBool
+
+// encodeBool encodes the provided value as a boolean into the writer
+func encodeBool(endianness binary.ByteOrder, value Value, writer io.Writer) error {
+	boolean, ok := value.(BooleanValue)
+	if !ok {
+		return ErrMismatchedTypes{Value: value}
+	}
+	return binary.Write(writer, endianness, boolean.inner)
 }
 
 // newDecodeEnum creates a new enum decoder for the given EnumDescriptor and name
@@ -52,5 +88,27 @@ func newDecodeEnum(name ValueName, descriptor EnumDescriptor) valueDecoder {
 		}
 
 		return NewEnumValue(descriptor[variantIdx]), nil
+	}
+}
+
+// newEncodeEnum creates a new enum encoder for the given EnumDescriptor and name
+func newEncodeEnum(name ValueName, descriptor EnumDescriptor) valueEncoder {
+	return func(endianness binary.ByteOrder, value Value, writer io.Writer) error {
+		enum, ok := value.(EnumValue)
+		if !ok {
+			return ErrMismatchedTypes{Value: value}
+		}
+
+		variantIdx := -1
+		for i, variant := range descriptor {
+			if variant == enum.Variant() {
+				variantIdx = i
+			}
+		}
+		if variantIdx < 0 {
+			return ErrUnexpectedVariant{Name: name, Variant: enum.Variant(), Descriptor: descriptor}
+		}
+
+		return binary.Write(writer, endianness, uint8(variantIdx))
 	}
 }

--- a/backend/pkg/transport/packet/data/descriptors.go
+++ b/backend/pkg/transport/packet/data/descriptors.go
@@ -14,11 +14,17 @@ type valueDescriptor struct {
 	Name   ValueName
 	Type   valueType
 	decode valueDecoder
+	encode valueEncoder
 }
 
 // Decode decodes the next value from the reader using its decoding method
 func (descriptor *valueDescriptor) Decode(endianness binary.ByteOrder, reader io.Reader) (Value, error) {
 	return descriptor.decode(endianness, reader)
+}
+
+// Encode encodes the provided value into the reader using its encoding method
+func (descriptor *valueDescriptor) Encode(endianness binary.ByteOrder, value Value, writer io.Writer) error {
+	return descriptor.encode(endianness, value, writer)
 }
 
 // NewNumericDescriptor creates a new NumericDescriptor
@@ -30,6 +36,7 @@ func NewNumericDescriptor[N numeric](name ValueName) valueDescriptor {
 		Name:   name,
 		Type:   valueType(reflect.TypeOf(n).Name()),
 		decode: decodeNumeric[N],
+		encode: encodeNumeric[N],
 	}
 }
 
@@ -41,6 +48,7 @@ func NewBooleanDescriptor(name ValueName) valueDescriptor {
 		Name:   name,
 		Type:   BoolType,
 		decode: decodeBool,
+		encode: encodeBool,
 	}
 }
 
@@ -52,5 +60,6 @@ func NewEnumDescriptor(name ValueName, descriptor EnumDescriptor) valueDescripto
 		Name:   name,
 		Type:   EnumType,
 		decode: newDecodeEnum(name, descriptor),
+		encode: newEncodeEnum(name, descriptor),
 	}
 }

--- a/backend/pkg/transport/packet/data/descriptors.go
+++ b/backend/pkg/transport/packet/data/descriptors.go
@@ -22,7 +22,7 @@ func (descriptor *valueDescriptor) Decode(endianness binary.ByteOrder, reader io
 	return descriptor.decode(endianness, reader)
 }
 
-// Encode encodes the provided value into the reader using its encoding method
+// Encode encodes the provided value into the writer using its encoding method
 func (descriptor *valueDescriptor) Encode(endianness binary.ByteOrder, value Value, writer io.Writer) error {
 	return descriptor.encode(endianness, value, writer)
 }

--- a/backend/pkg/transport/packet/data/encoder.go
+++ b/backend/pkg/transport/packet/data/encoder.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+// Encoder is the encoder for data packets. It uses the encoder defined on the value descriptor.
+type Encoder struct {
+	endianness      binary.ByteOrder
+	idToDescription map[abstraction.PacketId]Descriptor
+}
+
+// TODO: improve constructor
+// NewEncoder creates a new Encoder
+func NewEncoder(endianness binary.ByteOrder) *Encoder {
+	return &Encoder{
+		endianness:      endianness,
+		idToDescription: make(map[abstraction.PacketId]Descriptor),
+	}
+}
+
+// SetDescriptor sets the descriptor for the given id
+func (encoder *Encoder) SetDescriptor(id abstraction.PacketId, descriptor Descriptor) {
+	encoder.idToDescription[id] = descriptor
+}
+
+// Encode encodes the given packet to the output Writer, returning any errors it encounters
+func (encoder *Encoder) Encode(packet abstraction.Packet, output io.Writer) error {
+	data, ok := packet.(*Packet)
+	if !ok {
+		return ErrUnexpectedPacket{Packet: packet}
+	}
+	values := data.GetValues()
+
+	descriptor, ok := encoder.idToDescription[data.Id()]
+	if !ok {
+		return ErrUnexpectedId{packet.Id()}
+	}
+
+	for _, valueDescriptor := range descriptor {
+		value, ok := values[valueDescriptor.Name]
+		if !ok {
+			return ErrValueNotFound{Value: valueDescriptor, Packet: packet}
+		}
+
+		err := valueDescriptor.Encode(encoder.endianness, value, output)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/backend/pkg/transport/packet/data/errors.go
+++ b/backend/pkg/transport/packet/data/errors.go
@@ -43,3 +43,41 @@ type ErrInvalidVariant struct {
 func (err ErrInvalidVariant) Error() string {
 	return fmt.Sprintf("enum %s has %d variants, but tried to access the %d variant", err.Name, err.Len, err.Idx+1)
 }
+
+// ErrUnexpectedPacket is returned when a packet is given to an incorrect encoder
+type ErrUnexpectedPacket struct {
+	Packet abstraction.Packet
+}
+
+func (err ErrUnexpectedPacket) Error() string {
+	return fmt.Sprintf("expected data packet, got %T instead", err.Packet)
+}
+
+// ErrValueNotFound is returned when the provided packet is meassing a value that should be present
+type ErrValueNotFound struct {
+	Value  valueDescriptor
+	Packet abstraction.Packet
+}
+
+func (err ErrValueNotFound) Error() string {
+	return fmt.Sprintf("could not find value %s in packet %v", err.Value.Name, err.Packet)
+}
+
+// ErrMismatchedTypes is returned when the provided value does not match the encoder type
+type ErrMismatchedTypes struct {
+	Value Value
+}
+
+func (err ErrMismatchedTypes) Error() string {
+	return fmt.Sprintf("type of value type %T does not match the one of the encoder", err.Value)
+}
+
+type ErrUnexpectedVariant struct {
+	Name       ValueName
+	Variant    EnumVariant
+	Descriptor EnumDescriptor
+}
+
+func (err ErrUnexpectedVariant) Error() string {
+	return fmt.Sprintf("tried to encode %s variant for %s enum, but possibilities are only %v", err.Variant, err.Name, err.Descriptor)
+}

--- a/backend/pkg/transport/presentation/encoder.go
+++ b/backend/pkg/transport/presentation/encoder.go
@@ -1,3 +1,49 @@
 package presentation
 
-type PacketEncoder struct{}
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type PacketEncoder interface {
+	Encode(abstraction.Packet, io.Writer) error
+}
+
+type Encoder struct {
+	idToEncoder map[abstraction.PacketId]PacketEncoder
+	endianness  binary.ByteOrder
+}
+
+// TODO: improve constructor
+// NewEncoder creates a new encoder with the given endianness
+func NewEncoder(endianness binary.ByteOrder) Encoder {
+	return Encoder{
+		idToEncoder: make(map[abstraction.PacketId]PacketEncoder),
+		endianness:  endianness,
+	}
+}
+
+// SetPacketEncoder sets the encoder for the specified id
+func (encoder *Encoder) SetPacketEncoder(id abstraction.PacketId, enc PacketEncoder) {
+	encoder.idToEncoder[id] = enc
+}
+
+func (encoder *Encoder) Encode(packet abstraction.Packet) ([]byte, error) {
+	enc, ok := encoder.idToEncoder[packet.Id()]
+	if !ok {
+		return nil, ErrUnexpectedId{Id: packet.Id()}
+	}
+
+	buffer := new(bytes.Buffer)
+
+	err := binary.Write(buffer, encoder.endianness, packet.Id())
+	if err != nil {
+		return buffer.Bytes(), err
+	}
+
+	err = enc.Encode(packet, buffer)
+	return buffer.Bytes(), err
+}

--- a/backend/pkg/transport/presentation/encoder.go
+++ b/backend/pkg/transport/presentation/encoder.go
@@ -31,6 +31,7 @@ func (encoder *Encoder) SetPacketEncoder(id abstraction.PacketId, enc PacketEnco
 	encoder.idToEncoder[id] = enc
 }
 
+// Encode encodes the provided packet into a byte slice, returning any errors
 func (encoder *Encoder) Encode(packet abstraction.Packet) ([]byte, error) {
 	enc, ok := encoder.idToEncoder[packet.Id()]
 	if !ok {

--- a/backend/pkg/transport/presentation/encoder_test.go
+++ b/backend/pkg/transport/presentation/encoder_test.go
@@ -1,0 +1,486 @@
+package presentation_test
+
+import (
+	"encoding/binary"
+	"reflect"
+	"testing"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/data"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
+)
+
+func TestEncoder(t *testing.T) {
+	type testcase struct {
+		name   string
+		input  []abstraction.Packet
+		output []byte
+	}
+
+	endianness := binary.LittleEndian
+
+	testcases := []testcase{
+		{
+			name: "data 0",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(9, map[data.ValueName]data.Value{
+					"uint8":  data.NewNumericValue[uint8](8),
+					"uint16": data.NewNumericValue[uint16](8),
+					"uint32": data.NewNumericValue[uint32](8),
+					"uint64": data.NewNumericValue[uint64](8),
+				}),
+			},
+			output: (join(
+				[]byte{0x09, 0x00},
+				toBinary(uint8(8), endianness),
+				toBinary(uint16(8), endianness),
+				toBinary(uint32(8), endianness),
+				toBinary(uint64(8), endianness),
+			)),
+		},
+		{
+			name: "data 1",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(10, map[data.ValueName]data.Value{
+					"int8":  data.NewNumericValue[int8](8),
+					"int16": data.NewNumericValue[int16](8),
+					"int32": data.NewNumericValue[int32](8),
+					"int64": data.NewNumericValue[int64](8),
+				}),
+			},
+			output: (join(
+				[]byte{0x0a, 0x00},
+				toBinary(int8(8), endianness),
+				toBinary(int16(8), endianness),
+				toBinary(int32(8), endianness),
+				toBinary(int64(8), endianness),
+			)),
+		},
+		{
+			name: "data 2",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(11, map[data.ValueName]data.Value{
+					"float32": data.NewNumericValue[float32](8),
+					"float64": data.NewNumericValue[float64](8),
+				}),
+			},
+			output: (join(
+				[]byte{0x0b, 0x00},
+				toBinary(float32(8), endianness),
+				toBinary(float64(8), endianness),
+			)),
+		},
+		{
+			name: "data 3",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(12, map[data.ValueName]data.Value{
+					"bool": data.NewBooleanValue(true),
+				}),
+			},
+			output: (join(
+				[]byte{0x0c, 0x00},
+				[]byte{0x01},
+			)),
+		},
+		{
+			name: "data 4",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(13, map[data.ValueName]data.Value{
+					"enum": data.NewEnumValue("c"),
+				}),
+			},
+			output: (join(
+				[]byte{0x0d, 0x00},
+				toBinary(uint8(2), endianness),
+			)),
+		},
+		{
+			name: "data 5",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(14, map[data.ValueName]data.Value{
+					"uint8_1": data.NewNumericValue[uint8](8),
+					"uint8_2": data.NewNumericValue[uint8](8),
+					"float64": data.NewNumericValue[float64](8),
+					"bool":    data.NewBooleanValue(true),
+					"enum":    data.NewEnumValue("a"),
+				}),
+			},
+			output: (join(
+				[]byte{0x0e, 0x00},
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(float64(8), endianness),
+				[]byte{0x01},
+				toBinary(uint8(0), endianness),
+			)),
+		},
+		{
+			name: "data 6",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(15, map[data.ValueName]data.Value{
+					"bool_1": data.NewBooleanValue(true),
+					"bool_2": data.NewBooleanValue(false),
+					"bool_3": data.NewBooleanValue(false),
+				}),
+			},
+			output: (join(
+				[]byte{0x0f, 0x00},
+				[]byte{0x01},
+				[]byte{0x00},
+				[]byte{0x00},
+			)),
+		},
+		{
+			name: "data 7",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(16, map[data.ValueName]data.Value{
+					"enum_1": data.NewEnumValue("b"),
+					"enum_2": data.NewEnumValue("a"),
+					"enum_3": data.NewEnumValue("d"),
+					"enum_4": data.NewEnumValue("c"),
+					"enum_5": data.NewEnumValue("h"),
+				}),
+			},
+			output: (join(
+				[]byte{0x10, 0x00},
+				toBinary(uint8(1), endianness),
+				toBinary(uint8(0), endianness),
+				toBinary(uint8(3), endianness),
+				toBinary(uint8(2), endianness),
+				toBinary(uint8(7), endianness),
+			)),
+		},
+		{
+			name: "data 8",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(17, map[data.ValueName]data.Value{
+					"uint8_1":  data.NewNumericValue[uint8](8),
+					"uint8_2":  data.NewNumericValue[uint8](8),
+					"uint8_3":  data.NewNumericValue[uint8](8),
+					"uint8_4":  data.NewNumericValue[uint8](8),
+					"uint8_5":  data.NewNumericValue[uint8](8),
+					"uint8_6":  data.NewNumericValue[uint8](8),
+					"uint8_7":  data.NewNumericValue[uint8](8),
+					"uint8_8":  data.NewNumericValue[uint8](8),
+					"uint8_9":  data.NewNumericValue[uint8](8),
+					"uint8_10": data.NewNumericValue[uint8](8),
+				}),
+			},
+			output: (join(
+				[]byte{0x11, 0x00},
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+			)),
+		},
+		{
+			name: "data 9",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(18, map[data.ValueName]data.Value{
+					"uint64_1":  data.NewNumericValue[uint64](8),
+					"int64_1":   data.NewNumericValue[int64](8),
+					"float64_1": data.NewNumericValue[float64](8),
+					"uint64_2":  data.NewNumericValue[uint64](8),
+					"int64_2":   data.NewNumericValue[int64](8),
+					"float64_2": data.NewNumericValue[float64](8),
+					"uint64_3":  data.NewNumericValue[uint64](8),
+					"int64_3":   data.NewNumericValue[int64](8),
+					"float64_3": data.NewNumericValue[float64](8),
+					"uint64_4":  data.NewNumericValue[uint64](8),
+					"int64_4":   data.NewNumericValue[int64](8),
+					"float64_4": data.NewNumericValue[float64](8),
+					"uint64_5":  data.NewNumericValue[uint64](8),
+					"int64_5":   data.NewNumericValue[int64](8),
+					"float64_5": data.NewNumericValue[float64](8),
+					"uint64_6":  data.NewNumericValue[uint64](8),
+					"int64_6":   data.NewNumericValue[int64](8),
+					"float64_6": data.NewNumericValue[float64](8),
+				}),
+			},
+			output: (join(
+				[]byte{0x12, 0x00},
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+			)),
+		},
+		{
+			name: "multiple",
+			input: []abstraction.Packet{
+				data.NewPacketWithValues(9, map[data.ValueName]data.Value{
+					"uint8":  data.NewNumericValue[uint8](8),
+					"uint16": data.NewNumericValue[uint16](8),
+					"uint32": data.NewNumericValue[uint32](8),
+					"uint64": data.NewNumericValue[uint64](8),
+				}),
+				data.NewPacketWithValues(10, map[data.ValueName]data.Value{
+					"int8":  data.NewNumericValue[int8](8),
+					"int16": data.NewNumericValue[int16](8),
+					"int32": data.NewNumericValue[int32](8),
+					"int64": data.NewNumericValue[int64](8),
+				}),
+				data.NewPacketWithValues(11, map[data.ValueName]data.Value{
+					"float32": data.NewNumericValue[float32](8),
+					"float64": data.NewNumericValue[float64](8),
+				}),
+				data.NewPacketWithValues(12, map[data.ValueName]data.Value{
+					"bool": data.NewBooleanValue(true),
+				}),
+				data.NewPacketWithValues(13, map[data.ValueName]data.Value{
+					"enum": data.NewEnumValue("c"),
+				}),
+				data.NewPacketWithValues(14, map[data.ValueName]data.Value{
+					"uint8_1": data.NewNumericValue[uint8](8),
+					"uint8_2": data.NewNumericValue[uint8](8),
+					"float64": data.NewNumericValue[float64](8),
+					"bool":    data.NewBooleanValue(true),
+					"enum":    data.NewEnumValue("a"),
+				}),
+				data.NewPacketWithValues(15, map[data.ValueName]data.Value{
+					"bool_1": data.NewBooleanValue(true),
+					"bool_2": data.NewBooleanValue(false),
+					"bool_3": data.NewBooleanValue(false),
+				}),
+				data.NewPacketWithValues(16, map[data.ValueName]data.Value{
+					"enum_1": data.NewEnumValue("b"),
+					"enum_2": data.NewEnumValue("a"),
+					"enum_3": data.NewEnumValue("d"),
+					"enum_4": data.NewEnumValue("c"),
+					"enum_5": data.NewEnumValue("h"),
+				}),
+				data.NewPacketWithValues(17, map[data.ValueName]data.Value{
+					"uint8_1":  data.NewNumericValue[uint8](8),
+					"uint8_2":  data.NewNumericValue[uint8](8),
+					"uint8_3":  data.NewNumericValue[uint8](8),
+					"uint8_4":  data.NewNumericValue[uint8](8),
+					"uint8_5":  data.NewNumericValue[uint8](8),
+					"uint8_6":  data.NewNumericValue[uint8](8),
+					"uint8_7":  data.NewNumericValue[uint8](8),
+					"uint8_8":  data.NewNumericValue[uint8](8),
+					"uint8_9":  data.NewNumericValue[uint8](8),
+					"uint8_10": data.NewNumericValue[uint8](8),
+				}),
+				data.NewPacketWithValues(18, map[data.ValueName]data.Value{
+					"uint64_1":  data.NewNumericValue[uint64](8),
+					"int64_1":   data.NewNumericValue[int64](8),
+					"float64_1": data.NewNumericValue[float64](8),
+					"uint64_2":  data.NewNumericValue[uint64](8),
+					"int64_2":   data.NewNumericValue[int64](8),
+					"float64_2": data.NewNumericValue[float64](8),
+					"uint64_3":  data.NewNumericValue[uint64](8),
+					"int64_3":   data.NewNumericValue[int64](8),
+					"float64_3": data.NewNumericValue[float64](8),
+					"uint64_4":  data.NewNumericValue[uint64](8),
+					"int64_4":   data.NewNumericValue[int64](8),
+					"float64_4": data.NewNumericValue[float64](8),
+					"uint64_5":  data.NewNumericValue[uint64](8),
+					"int64_5":   data.NewNumericValue[int64](8),
+					"float64_5": data.NewNumericValue[float64](8),
+					"uint64_6":  data.NewNumericValue[uint64](8),
+					"int64_6":   data.NewNumericValue[int64](8),
+					"float64_6": data.NewNumericValue[float64](8),
+				}),
+			},
+			output: (join(
+				[]byte{0x09, 0x00},
+				toBinary(uint8(8), endianness),
+				toBinary(uint16(8), endianness),
+				toBinary(uint32(8), endianness),
+				toBinary(uint64(8), endianness),
+				[]byte{0x0a, 0x00},
+				toBinary(int8(8), endianness),
+				toBinary(int16(8), endianness),
+				toBinary(int32(8), endianness),
+				toBinary(int64(8), endianness),
+				[]byte{0x0b, 0x00},
+				toBinary(float32(8), endianness),
+				toBinary(float64(8), endianness),
+				[]byte{0x0c, 0x00},
+				[]byte{0x01},
+				[]byte{0x0d, 0x00},
+				toBinary(uint8(2), endianness),
+				[]byte{0x0e, 0x00},
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(float64(8), endianness),
+				[]byte{0x01},
+				toBinary(uint8(0), endianness),
+				[]byte{0x0f, 0x00},
+				[]byte{0x01},
+				[]byte{0x00},
+				[]byte{0x00},
+				[]byte{0x10, 0x00},
+				toBinary(uint8(1), endianness),
+				toBinary(uint8(0), endianness),
+				toBinary(uint8(3), endianness),
+				toBinary(uint8(2), endianness),
+				toBinary(uint8(7), endianness),
+				[]byte{0x11, 0x00},
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				toBinary(uint8(8), endianness),
+				[]byte{0x12, 0x00},
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+				toBinary(uint64(8), endianness),
+				toBinary(int64(8), endianness),
+				toBinary(float64(8), endianness),
+			)),
+		},
+	}
+
+	for _, test := range testcases {
+		t.Run(test.name, func(t *testing.T) {
+			encoder := getEncoder(endianness)
+
+			output := make([]byte, 0, len(test.output))
+			for i := 0; i < len(test.input); i++ {
+				encoded, err := encoder.Encode(test.input[i])
+				if err != nil {
+					t.Fatalf("\nError encoding (%d) packet: %s\n", i+1, err)
+				}
+
+				output = append(output, encoded...)
+
+			}
+			if !reflect.DeepEqual(output, test.output) {
+				t.Fatalf("\nGot %#v\nExpected %#v\n", output, test.output)
+			}
+		})
+	}
+}
+
+// getEncoder generates a mock Encoder with the following packet IDs:
+// 9:=18 - data
+func getEncoder(endianness binary.ByteOrder) presentation.Encoder {
+	encoder := presentation.NewEncoder(endianness)
+
+	dataDecoder := data.NewEncoder(endianness)
+	dataDecoder.SetDescriptor(9, data.Descriptor{
+		data.NewNumericDescriptor[uint8]("uint8"),
+		data.NewNumericDescriptor[uint16]("uint16"),
+		data.NewNumericDescriptor[uint32]("uint32"),
+		data.NewNumericDescriptor[uint64]("uint64"),
+	})
+	dataDecoder.SetDescriptor(10, data.Descriptor{
+		data.NewNumericDescriptor[int8]("int8"),
+		data.NewNumericDescriptor[int16]("int16"),
+		data.NewNumericDescriptor[int32]("int32"),
+		data.NewNumericDescriptor[int64]("int64"),
+	})
+	dataDecoder.SetDescriptor(11, data.Descriptor{
+		data.NewNumericDescriptor[float32]("float32"),
+		data.NewNumericDescriptor[float64]("float64"),
+	})
+	dataDecoder.SetDescriptor(12, data.Descriptor{
+		data.NewBooleanDescriptor("bool"),
+	})
+	dataDecoder.SetDescriptor(13, data.Descriptor{
+		data.NewEnumDescriptor("enum", data.EnumDescriptor{"a", "b", "c", "d"}),
+	})
+	dataDecoder.SetDescriptor(14, data.Descriptor{
+		data.NewNumericDescriptor[uint8]("uint8_1"),
+		data.NewNumericDescriptor[uint8]("uint8_2"),
+		data.NewNumericDescriptor[float64]("float64"),
+		data.NewBooleanDescriptor("bool"),
+		data.NewEnumDescriptor("enum", data.EnumDescriptor{"a", "b", "c"}),
+	})
+	dataDecoder.SetDescriptor(15, data.Descriptor{
+		data.NewBooleanDescriptor("bool_1"),
+		data.NewBooleanDescriptor("bool_2"),
+		data.NewBooleanDescriptor("bool_3"),
+	})
+	dataDecoder.SetDescriptor(16, data.Descriptor{
+		data.NewEnumDescriptor("enum_1", data.EnumDescriptor{"a", "b", "c"}),
+		data.NewEnumDescriptor("enum_2", data.EnumDescriptor{"a", "b"}),
+		data.NewEnumDescriptor("enum_3", data.EnumDescriptor{"a", "b", "c", "d", "e"}),
+		data.NewEnumDescriptor("enum_4", data.EnumDescriptor{"a", "b", "c", "d"}),
+		data.NewEnumDescriptor("enum_5", data.EnumDescriptor{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
+	})
+	dataDecoder.SetDescriptor(17, data.Descriptor{
+		data.NewNumericDescriptor[uint8]("uint8_1"),
+		data.NewNumericDescriptor[uint8]("uint8_2"),
+		data.NewNumericDescriptor[uint8]("uint8_3"),
+		data.NewNumericDescriptor[uint8]("uint8_4"),
+		data.NewNumericDescriptor[uint8]("uint8_5"),
+		data.NewNumericDescriptor[uint8]("uint8_6"),
+		data.NewNumericDescriptor[uint8]("uint8_7"),
+		data.NewNumericDescriptor[uint8]("uint8_8"),
+		data.NewNumericDescriptor[uint8]("uint8_9"),
+		data.NewNumericDescriptor[uint8]("uint8_10"),
+	})
+	dataDecoder.SetDescriptor(18, data.Descriptor{
+		data.NewNumericDescriptor[uint64]("uint64_1"),
+		data.NewNumericDescriptor[int64]("int64_1"),
+		data.NewNumericDescriptor[float64]("float64_1"),
+		data.NewNumericDescriptor[uint64]("uint64_2"),
+		data.NewNumericDescriptor[int64]("int64_2"),
+		data.NewNumericDescriptor[float64]("float64_2"),
+		data.NewNumericDescriptor[uint64]("uint64_3"),
+		data.NewNumericDescriptor[int64]("int64_3"),
+		data.NewNumericDescriptor[float64]("float64_3"),
+		data.NewNumericDescriptor[uint64]("uint64_4"),
+		data.NewNumericDescriptor[int64]("int64_4"),
+		data.NewNumericDescriptor[float64]("float64_4"),
+		data.NewNumericDescriptor[uint64]("uint64_5"),
+		data.NewNumericDescriptor[int64]("int64_5"),
+		data.NewNumericDescriptor[float64]("float64_5"),
+		data.NewNumericDescriptor[uint64]("uint64_6"),
+		data.NewNumericDescriptor[int64]("int64_6"),
+		data.NewNumericDescriptor[float64]("float64_6"),
+	})
+	encoder.SetPacketEncoder(9, dataDecoder)
+	encoder.SetPacketEncoder(10, dataDecoder)
+	encoder.SetPacketEncoder(11, dataDecoder)
+	encoder.SetPacketEncoder(12, dataDecoder)
+	encoder.SetPacketEncoder(13, dataDecoder)
+	encoder.SetPacketEncoder(14, dataDecoder)
+	encoder.SetPacketEncoder(15, dataDecoder)
+	encoder.SetPacketEncoder(16, dataDecoder)
+	encoder.SetPacketEncoder(17, dataDecoder)
+	encoder.SetPacketEncoder(18, dataDecoder)
+
+	return encoder
+}

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -17,7 +17,7 @@ import (
 // action to take.
 type Transport struct {
 	decoder *presentation.Decoder
-	encoder *presentation.PacketEncoder
+	encoder *presentation.Encoder
 
 	snifferDemux *session.SnifferDemux
 


### PR DESCRIPTION
This PR adds the encoder for packets. The encoder is used to serialize the orders we want to send to the vehicle. Orders are like data packets and use the same structs to define the order.

I've also added tests to check the functionality works correctly