### PR TITLE
[backend] [PR1] transport implementation

### DIFF
--- a/backend/pkg/abstraction/transport.go
+++ b/backend/pkg/abstraction/transport.go
@@ -32,4 +32,5 @@ type Transport interface {
 type TransportAPI interface {
 	// Notification notifies the back-end that an event has been received
 	Notification(TransportNotification)
+	ConnectionUpdate(TransportTarget, bool)
 }

--- a/backend/pkg/transport/constructor.go
+++ b/backend/pkg/transport/constructor.go
@@ -1,0 +1,36 @@
+package transport
+
+import (
+	"net"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/network/tftp"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/presentation"
+)
+
+func NewTransport() *Transport {
+	return &Transport{
+		connections: make(map[abstraction.TransportTarget]net.Conn),
+		idToTarget:  make(map[abstraction.PacketId]abstraction.TransportTarget),
+	}
+}
+
+func (transport *Transport) WithDecoder(decoder *presentation.Decoder) *Transport {
+	transport.decoder = decoder
+	return transport
+}
+
+func (transport *Transport) WithEncoder(encoder *presentation.Encoder) *Transport {
+	transport.encoder = encoder
+	return transport
+}
+
+func (transport *Transport) WithTFTP(client *tftp.Client) *Transport {
+	transport.tftp = client
+	return transport
+}
+
+func (transport *Transport) SetIdTarget(id abstraction.PacketId, target abstraction.TransportTarget) *Transport {
+	transport.idToTarget[id] = target
+	return transport
+}

--- a/backend/pkg/transport/errors.go
+++ b/backend/pkg/transport/errors.go
@@ -15,3 +15,11 @@ type ErrUnrecognizedEvent struct {
 func (err ErrUnrecognizedEvent) Error() string {
 	return fmt.Sprintf("unrecognized event %s", err.event)
 }
+
+type ErrTargetAlreadyConnected struct {
+	Target abstraction.TransportTarget
+}
+
+func (err ErrTargetAlreadyConnected) Error() string {
+	return fmt.Sprintf("%s is already connected", err.Target)
+}

--- a/backend/pkg/transport/errors.go
+++ b/backend/pkg/transport/errors.go
@@ -9,11 +9,11 @@ import (
 // ErrUnrecognizedEvent is returned when the event passed to transport
 // has an invalid type or it is not recognized.
 type ErrUnrecognizedEvent struct {
-	event abstraction.TransportEvent
+	Event abstraction.TransportEvent
 }
 
 func (err ErrUnrecognizedEvent) Error() string {
-	return fmt.Sprintf("unrecognized event %s", err.event)
+	return fmt.Sprintf("unrecognized event %s", err.Event)
 }
 
 type ErrTargetAlreadyConnected struct {
@@ -22,4 +22,20 @@ type ErrTargetAlreadyConnected struct {
 
 func (err ErrTargetAlreadyConnected) Error() string {
 	return fmt.Sprintf("%s is already connected", err.Target)
+}
+
+type ErrUnrecognizedId struct {
+	Id abstraction.PacketId
+}
+
+func (err ErrUnrecognizedId) Error() string {
+	return fmt.Sprintf("could not find target for packet with id %d", err.Id)
+}
+
+type ErrConnClosed struct {
+	Target abstraction.TransportTarget
+}
+
+func (err ErrConnClosed) Error() string {
+	return fmt.Sprintf("connection with %s is closed", err.Target)
 }

--- a/backend/pkg/transport/messages.go
+++ b/backend/pkg/transport/messages.go
@@ -17,28 +17,18 @@ const (
 
 // PacketMessage request a packet to be sent to the vehicle.
 type PacketMessage struct {
-	packet abstraction.Packet
+	abstraction.Packet
 }
 
 func NewPacketMessage(packet abstraction.Packet) PacketMessage {
 	return PacketMessage{
-		packet: packet,
+		Packet: packet,
 	}
 }
 
 // Event always returns PacketEvent
 func (message PacketMessage) Event() abstraction.TransportEvent {
 	return PacketEvent
-}
-
-// Packet returns the packet associated with the message
-func (message PacketMessage) Packet() abstraction.Packet {
-	return message.packet
-}
-
-// Id returns the Id of the packet associated with the message
-func (message PacketMessage) Id() abstraction.PacketId {
-	return message.packet.Id()
 }
 
 // FileWriteMessage request a file to be written to a specific target

--- a/backend/pkg/transport/messages.go
+++ b/backend/pkg/transport/messages.go
@@ -43,12 +43,14 @@ func (message PacketMessage) Id() abstraction.PacketId {
 
 // FileWriteMessage request a file to be written to a specific target
 type FileWriteMessage struct {
-	data io.Reader
+	filename string
+	io.Reader
 }
 
-func NewFileWriteMessage(data io.Reader) FileWriteMessage {
+func NewFileWriteMessage(filename string, input io.Reader) FileWriteMessage {
 	return FileWriteMessage{
-		data: data,
+		filename: filename,
+		Reader:   input,
 	}
 }
 
@@ -57,24 +59,20 @@ func (message FileWriteMessage) Event() abstraction.TransportEvent {
 	return FileWriteEvent
 }
 
-// Data returns the data to be written through tftp
-func (message FileWriteMessage) Data() io.Reader {
-	return message.data
-}
-
-// Read maps the message data read method so it can be used directly
-func (message FileWriteMessage) Read(p []byte) (n int, err error) {
-	return message.data.Read(p)
+func (message FileWriteMessage) Filename() string {
+	return message.filename
 }
 
 // FileReadMessage request a file to be read from the specific target.
 type FileReadMessage struct {
-	output io.Writer
+	filename string
+	io.Writer
 }
 
-func NewFileReadMessage(output io.Writer) FileReadMessage {
+func NewFileReadMessage(filename string, output io.Writer) FileReadMessage {
 	return FileReadMessage{
-		output: output,
+		filename: filename,
+		Writer:   output,
 	}
 }
 
@@ -83,12 +81,6 @@ func (message FileReadMessage) Event() abstraction.TransportEvent {
 	return FileReadEvent
 }
 
-// Output returns where data read should be written
-func (message FileReadMessage) Output() io.Writer {
-	return message.output
-}
-
-// Write maps the message output write method
-func (message FileReadMessage) Write(p []byte) (n int, err error) {
-	return message.output.Write(p)
+func (message FileReadMessage) Filename() string {
+	return message.filename
 }

--- a/backend/pkg/transport/network/tcp/conn.go
+++ b/backend/pkg/transport/network/tcp/conn.go
@@ -1,0 +1,40 @@
+package tcp
+
+import (
+	"errors"
+	"net"
+)
+
+type connWithErr struct {
+	net.Conn
+	errors chan<- error
+}
+
+func WithErrChan(conn net.Conn) (net.Conn, <-chan error) {
+	errChan := make(chan error, 1)
+	return &connWithErr{
+		Conn:   conn,
+		errors: errChan,
+	}, errChan
+}
+
+func (conn *connWithErr) Read(b []byte) (n int, err error) {
+	n, err = conn.Conn.Read(b)
+	if err != nil && !errors.Is(err, net.ErrClosed) {
+		conn.errors <- err
+	}
+	return
+}
+
+func (conn *connWithErr) Write(b []byte) (n int, err error) {
+	n, err = conn.Conn.Write(b)
+	if err != nil && !errors.Is(err, net.ErrClosed) {
+		conn.errors <- err
+	}
+	return
+}
+
+func (conn *connWithErr) Close() error {
+	close(conn.errors)
+	return conn.Conn.Close()
+}

--- a/backend/pkg/transport/notifications.go
+++ b/backend/pkg/transport/notifications.go
@@ -4,26 +4,16 @@ import "github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 
 // PacketNofitication notifies of an incoming message
 type PacketNotification struct {
-	packet abstraction.Packet
+	abstraction.Packet
 }
 
 func NewPacketNotification(packet abstraction.Packet) PacketNotification {
 	return PacketNotification{
-		packet: packet,
+		Packet: packet,
 	}
 }
 
 // Event always returns PacketEvent
 func (notification PacketNotification) Event() abstraction.TransportEvent {
 	return PacketEvent
-}
-
-// Packet returns the packet associated with the message
-func (notification PacketNotification) Packet() abstraction.Packet {
-	return notification.packet
-}
-
-// Id returns the id of the packet associated with the message
-func (notification PacketNotification) Id() abstraction.PacketId {
-	return notification.packet.Id()
 }

--- a/backend/pkg/transport/session/sniffer.go
+++ b/backend/pkg/transport/session/sniffer.go
@@ -44,7 +44,7 @@ func (demux *SnifferDemux) ReadPackets(reader packetReader) error {
 
 		conversation, ok := demux.conversations[socket]
 		if !ok {
-			demux.conversations[socket] = new(bytes.Buffer)
+			demux.conversations[socket] = new(bytes.Buffer) // TODO: this reader implementation does not exactly work as we want
 			conversation = demux.conversations[socket]
 			demux.onConversation(socket, conversation)
 		}

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -115,7 +115,7 @@ func (transport *Transport) handlePacketEvent(message PacketMessage) error {
 		return ErrConnClosed{Target: target}
 	}
 
-	data, err := transport.encoder.Encode(message.Packet())
+	data, err := transport.encoder.Encode(message)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -133,11 +133,13 @@ func (transport *Transport) handlePacketEvent(message PacketMessage) error {
 }
 
 func (transport *Transport) handleFileWrite(message FileWriteMessage) error {
-	panic("TODO!")
+	_, err := transport.tftp.WriteFile(message.Filename(), tftp.BinaryMode, message)
+	return err
 }
 
 func (transport *Transport) handleFileRead(message FileReadMessage) error {
-	panic("TODO!")
+	_, err := transport.tftp.ReadFile(message.Filename(), tftp.BinaryMode, message)
+	return err
 }
 
 func (transport *Transport) HandleSniffer(sniffer *sniffer.Sniffer) error {
@@ -160,5 +162,4 @@ func (transport *Transport) handleConversation(socket network.Socket, reader io.
 // SetAPI sets the API that the Transport will use
 func (transport *Transport) SetAPI(api abstraction.TransportAPI) {
 	transport.api = api
-	// TODO: make decoder use the api Notify method
 }


### PR DESCRIPTION
This is the first of two PRs that implement the transport functionality on the already existing code. On this one I implemented the internal implementation of the transport module, which takes the `sniffer`, `tcp`, `decoder`, `encoder`, `tftp`, etc. And puts it all together in a (hopefully) nice to use interface.

The current way to build and use the transport module is very manual in nature, having to specify everything yourself and having to construct the independent parts beforehand. The idea is to improve this way of building it over time, but for now this should work fine.