### PR TITLE
[backend] Unit Converter

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/internal/data_transfer"
 	"github.com/HyperloopUPV-H8/h9-backend/internal/excel"
 	"github.com/HyperloopUPV-H8/h9-backend/internal/excel/ade"
+	"github.com/HyperloopUPV-H8/h9-backend/internal/excel/utils"
 	"github.com/HyperloopUPV-H8/h9-backend/internal/info"
 	"github.com/HyperloopUPV-H8/h9-backend/internal/logger_handler"
 	protection_logger "github.com/HyperloopUPV-H8/h9-backend/internal/message_logger"
@@ -436,27 +437,29 @@ func getTransportDecEnc(info info.Info, podData pod_data.PodData) (*presentation
 			for i, measurement := range packet.Measurements {
 				switch meas := measurement.(type) {
 				case pod_data.NumericMeasurement:
+					podOps := getOps(meas.PodUnits)
+					displayOps := getOps(meas.DisplayUnits)
 					switch meas.Type {
 					case "uint8":
-						descriptor[i] = data.NewNumericDescriptor[uint8](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[uint8](data.ValueName(meas.Id), podOps, displayOps)
 					case "uint16":
-						descriptor[i] = data.NewNumericDescriptor[uint16](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[uint16](data.ValueName(meas.Id), podOps, displayOps)
 					case "uint32":
-						descriptor[i] = data.NewNumericDescriptor[uint32](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[uint32](data.ValueName(meas.Id), podOps, displayOps)
 					case "uint64":
-						descriptor[i] = data.NewNumericDescriptor[uint64](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[uint64](data.ValueName(meas.Id), podOps, displayOps)
 					case "int8":
-						descriptor[i] = data.NewNumericDescriptor[int8](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[int8](data.ValueName(meas.Id), podOps, displayOps)
 					case "int16":
-						descriptor[i] = data.NewNumericDescriptor[int16](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[int16](data.ValueName(meas.Id), podOps, displayOps)
 					case "int32":
-						descriptor[i] = data.NewNumericDescriptor[int32](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[int32](data.ValueName(meas.Id), podOps, displayOps)
 					case "int64":
-						descriptor[i] = data.NewNumericDescriptor[int64](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[int64](data.ValueName(meas.Id), podOps, displayOps)
 					case "float32":
-						descriptor[i] = data.NewNumericDescriptor[float32](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[float32](data.ValueName(meas.Id), podOps, displayOps)
 					case "float64":
-						descriptor[i] = data.NewNumericDescriptor[float64](data.ValueName(meas.Id))
+						descriptor[i] = data.NewNumericDescriptor[float64](data.ValueName(meas.Id), podOps, displayOps)
 					default:
 						panic(fmt.Sprintf("unexpected numeric type for %s: %s", meas.Id, meas.Type))
 					}
@@ -498,6 +501,17 @@ func getTransportDecEnc(info info.Info, podData pod_data.PodData) (*presentation
 	protectionDecoder.SetSeverity(abstraction.PacketId(info.MessageIds.Fault), protection.SeverityFault)
 
 	return decoder, encoder
+}
+
+func getOps(units utils.Units) data.ConversionDescriptor {
+	output := make(data.ConversionDescriptor, len(units.Operations))
+	for i, operation := range units.Operations {
+		output[i] = data.Operation{
+			Operator: operation.Operator,
+			Operand:  operation.Operand,
+		}
+	}
+	return output
 }
 
 type TransportAPI struct {

--- a/backend/pkg/transport/packet/data/converter.go
+++ b/backend/pkg/transport/packet/data/converter.go
@@ -1,0 +1,81 @@
+package data
+
+type valueConverter func(Value) Value
+type valueReverter func(Value) Value
+
+type ConversionDescriptor []Operation
+
+type Operation struct {
+	Operator string
+	Operand  float64
+}
+
+func newConvertNumeric[N numeric](podConversion, displayConversion ConversionDescriptor) valueConverter {
+	return func(value Value) Value {
+		numeric := value.(NumericValue[N])
+		for _, operation := range append(podConversion, displayConversion...) {
+			switch operation.Operator {
+			case "+":
+				numeric.inner += N(operation.Operand)
+			case "-":
+				numeric.inner -= N(operation.Operand)
+			case "*":
+				numeric.inner *= N(operation.Operand)
+			case "/":
+				numeric.inner /= N(operation.Operand)
+			}
+		}
+		return numeric
+	}
+}
+
+func newRevertNumeric[N numeric](podConversion, displayConversion ConversionDescriptor) valueReverter {
+	return func(value Value) Value {
+		numeric := value.(NumericValue[N])
+		for i := len(displayConversion) - 1; i >= 0; i-- {
+			operation := displayConversion[i]
+			switch operation.Operator {
+			case "+":
+				numeric.inner -= N(operation.Operand)
+			case "-":
+				numeric.inner += N(operation.Operand)
+			case "*":
+				numeric.inner /= N(operation.Operand)
+			case "/":
+				numeric.inner *= N(operation.Operand)
+			}
+		}
+
+		for i := len(podConversion) - 1; i >= 0; i-- {
+			operation := podConversion[i]
+			switch operation.Operator {
+			case "+":
+				numeric.inner -= N(operation.Operand)
+			case "-":
+				numeric.inner += N(operation.Operand)
+			case "*":
+				numeric.inner /= N(operation.Operand)
+			case "/":
+				numeric.inner *= N(operation.Operand)
+			}
+		}
+
+		return numeric
+	}
+}
+
+func convertBoolean(value Value) Value {
+	return value
+}
+
+func revertBoolean(value Value) Value {
+	return value
+}
+
+func convertEnum(value Value) Value {
+	return value
+}
+
+func revertEnum(value Value) Value {
+	return value
+}

--- a/backend/pkg/transport/packet/data/descriptors.go
+++ b/backend/pkg/transport/packet/data/descriptors.go
@@ -11,32 +11,40 @@ type Descriptor []valueDescriptor
 
 // valueDescriptor describes a value of a packet
 type valueDescriptor struct {
-	Name   ValueName
-	Type   valueType
-	decode valueDecoder
-	encode valueEncoder
+	Name    ValueName
+	Type    valueType
+	decode  valueDecoder
+	encode  valueEncoder
+	convert valueConverter
+	revert  valueReverter
 }
 
 // Decode decodes the next value from the reader using its decoding method
 func (descriptor *valueDescriptor) Decode(endianness binary.ByteOrder, reader io.Reader) (Value, error) {
-	return descriptor.decode(endianness, reader)
+	value, err := descriptor.decode(endianness, reader)
+	if err != nil {
+		return value, err
+	}
+	return descriptor.convert(value), nil
 }
 
 // Encode encodes the provided value into the writer using its encoding method
 func (descriptor *valueDescriptor) Encode(endianness binary.ByteOrder, value Value, writer io.Writer) error {
-	return descriptor.encode(endianness, value, writer)
+	return descriptor.encode(endianness, descriptor.revert(value), writer)
 }
 
 // NewNumericDescriptor creates a new NumericDescriptor
 //
 // name is the name for the value
-func NewNumericDescriptor[N numeric](name ValueName) valueDescriptor {
+func NewNumericDescriptor[N numeric](name ValueName, podUnits, displayUnits ConversionDescriptor) valueDescriptor {
 	var n N
 	return valueDescriptor{
-		Name:   name,
-		Type:   valueType(reflect.TypeOf(n).Name()),
-		decode: decodeNumeric[N],
-		encode: encodeNumeric[N],
+		Name:    name,
+		Type:    valueType(reflect.TypeOf(n).Name()),
+		decode:  decodeNumeric[N],
+		encode:  encodeNumeric[N],
+		convert: newConvertNumeric[N](podUnits, displayUnits),
+		revert:  newRevertNumeric[N](podUnits, displayUnits),
 	}
 }
 
@@ -45,10 +53,12 @@ func NewNumericDescriptor[N numeric](name ValueName) valueDescriptor {
 // name is the name for the value
 func NewBooleanDescriptor(name ValueName) valueDescriptor {
 	return valueDescriptor{
-		Name:   name,
-		Type:   BoolType,
-		decode: decodeBool,
-		encode: encodeBool,
+		Name:    name,
+		Type:    BoolType,
+		decode:  decodeBool,
+		encode:  encodeBool,
+		convert: convertBoolean,
+		revert:  revertBoolean,
 	}
 }
 
@@ -57,9 +67,11 @@ func NewBooleanDescriptor(name ValueName) valueDescriptor {
 // name is the name for the value and descriptor is the variants the enum has
 func NewEnumDescriptor(name ValueName, descriptor EnumDescriptor) valueDescriptor {
 	return valueDescriptor{
-		Name:   name,
-		Type:   EnumType,
-		decode: newDecodeEnum(name, descriptor),
-		encode: newEncodeEnum(name, descriptor),
+		Name:    name,
+		Type:    EnumType,
+		decode:  newDecodeEnum(name, descriptor),
+		encode:  newEncodeEnum(name, descriptor),
+		convert: convertEnum,
+		revert:  revertEnum,
 	}
 }

--- a/backend/pkg/transport/presentation/decoder_test.go
+++ b/backend/pkg/transport/presentation/decoder_test.go
@@ -1056,20 +1056,20 @@ func getDecoder(endianness binary.ByteOrder) *presentation.Decoder {
 
 	dataDecoder := data.NewDecoder(endianness)
 	dataDecoder.SetDescriptor(9, data.Descriptor{
-		data.NewNumericDescriptor[uint8]("uint8"),
-		data.NewNumericDescriptor[uint16]("uint16"),
-		data.NewNumericDescriptor[uint32]("uint32"),
-		data.NewNumericDescriptor[uint64]("uint64"),
+		data.NewNumericDescriptor[uint8]("uint8", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint16]("uint16", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint32]("uint32", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(10, data.Descriptor{
-		data.NewNumericDescriptor[int8]("int8"),
-		data.NewNumericDescriptor[int16]("int16"),
-		data.NewNumericDescriptor[int32]("int32"),
-		data.NewNumericDescriptor[int64]("int64"),
+		data.NewNumericDescriptor[int8]("int8", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int16]("int16", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int32]("int32", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(11, data.Descriptor{
-		data.NewNumericDescriptor[float32]("float32"),
-		data.NewNumericDescriptor[float64]("float64"),
+		data.NewNumericDescriptor[float32]("float32", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(12, data.Descriptor{
 		data.NewBooleanDescriptor("bool"),
@@ -1078,9 +1078,9 @@ func getDecoder(endianness binary.ByteOrder) *presentation.Decoder {
 		data.NewEnumDescriptor("enum", data.EnumDescriptor{"a", "b", "c", "d"}),
 	})
 	dataDecoder.SetDescriptor(14, data.Descriptor{
-		data.NewNumericDescriptor[uint8]("uint8_1"),
-		data.NewNumericDescriptor[uint8]("uint8_2"),
-		data.NewNumericDescriptor[float64]("float64"),
+		data.NewNumericDescriptor[uint8]("uint8_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 		data.NewBooleanDescriptor("bool"),
 		data.NewEnumDescriptor("enum", data.EnumDescriptor{"a", "b", "c"}),
 	})
@@ -1097,36 +1097,36 @@ func getDecoder(endianness binary.ByteOrder) *presentation.Decoder {
 		data.NewEnumDescriptor("enum_5", data.EnumDescriptor{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
 	})
 	dataDecoder.SetDescriptor(17, data.Descriptor{
-		data.NewNumericDescriptor[uint8]("uint8_1"),
-		data.NewNumericDescriptor[uint8]("uint8_2"),
-		data.NewNumericDescriptor[uint8]("uint8_3"),
-		data.NewNumericDescriptor[uint8]("uint8_4"),
-		data.NewNumericDescriptor[uint8]("uint8_5"),
-		data.NewNumericDescriptor[uint8]("uint8_6"),
-		data.NewNumericDescriptor[uint8]("uint8_7"),
-		data.NewNumericDescriptor[uint8]("uint8_8"),
-		data.NewNumericDescriptor[uint8]("uint8_9"),
-		data.NewNumericDescriptor[uint8]("uint8_10"),
+		data.NewNumericDescriptor[uint8]("uint8_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_7", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_8", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_9", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_10", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(18, data.Descriptor{
-		data.NewNumericDescriptor[uint64]("uint64_1"),
-		data.NewNumericDescriptor[int64]("int64_1"),
-		data.NewNumericDescriptor[float64]("float64_1"),
-		data.NewNumericDescriptor[uint64]("uint64_2"),
-		data.NewNumericDescriptor[int64]("int64_2"),
-		data.NewNumericDescriptor[float64]("float64_2"),
-		data.NewNumericDescriptor[uint64]("uint64_3"),
-		data.NewNumericDescriptor[int64]("int64_3"),
-		data.NewNumericDescriptor[float64]("float64_3"),
-		data.NewNumericDescriptor[uint64]("uint64_4"),
-		data.NewNumericDescriptor[int64]("int64_4"),
-		data.NewNumericDescriptor[float64]("float64_4"),
-		data.NewNumericDescriptor[uint64]("uint64_5"),
-		data.NewNumericDescriptor[int64]("int64_5"),
-		data.NewNumericDescriptor[float64]("float64_5"),
-		data.NewNumericDescriptor[uint64]("uint64_6"),
-		data.NewNumericDescriptor[int64]("int64_6"),
-		data.NewNumericDescriptor[float64]("float64_6"),
+		data.NewNumericDescriptor[uint64]("uint64_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	decoder.SetPacketDecoder(9, dataDecoder)
 	decoder.SetPacketDecoder(10, dataDecoder)

--- a/backend/pkg/transport/presentation/encoder_test.go
+++ b/backend/pkg/transport/presentation/encoder_test.go
@@ -400,20 +400,20 @@ func getEncoder(endianness binary.ByteOrder) *presentation.Encoder {
 
 	dataDecoder := data.NewEncoder(endianness)
 	dataDecoder.SetDescriptor(9, data.Descriptor{
-		data.NewNumericDescriptor[uint8]("uint8"),
-		data.NewNumericDescriptor[uint16]("uint16"),
-		data.NewNumericDescriptor[uint32]("uint32"),
-		data.NewNumericDescriptor[uint64]("uint64"),
+		data.NewNumericDescriptor[uint8]("uint8", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint16]("uint16", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint32]("uint32", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(10, data.Descriptor{
-		data.NewNumericDescriptor[int8]("int8"),
-		data.NewNumericDescriptor[int16]("int16"),
-		data.NewNumericDescriptor[int32]("int32"),
-		data.NewNumericDescriptor[int64]("int64"),
+		data.NewNumericDescriptor[int8]("int8", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int16]("int16", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int32]("int32", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(11, data.Descriptor{
-		data.NewNumericDescriptor[float32]("float32"),
-		data.NewNumericDescriptor[float64]("float64"),
+		data.NewNumericDescriptor[float32]("float32", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(12, data.Descriptor{
 		data.NewBooleanDescriptor("bool"),
@@ -422,9 +422,9 @@ func getEncoder(endianness binary.ByteOrder) *presentation.Encoder {
 		data.NewEnumDescriptor("enum", data.EnumDescriptor{"a", "b", "c", "d"}),
 	})
 	dataDecoder.SetDescriptor(14, data.Descriptor{
-		data.NewNumericDescriptor[uint8]("uint8_1"),
-		data.NewNumericDescriptor[uint8]("uint8_2"),
-		data.NewNumericDescriptor[float64]("float64"),
+		data.NewNumericDescriptor[uint8]("uint8_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 		data.NewBooleanDescriptor("bool"),
 		data.NewEnumDescriptor("enum", data.EnumDescriptor{"a", "b", "c"}),
 	})
@@ -441,36 +441,36 @@ func getEncoder(endianness binary.ByteOrder) *presentation.Encoder {
 		data.NewEnumDescriptor("enum_5", data.EnumDescriptor{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}),
 	})
 	dataDecoder.SetDescriptor(17, data.Descriptor{
-		data.NewNumericDescriptor[uint8]("uint8_1"),
-		data.NewNumericDescriptor[uint8]("uint8_2"),
-		data.NewNumericDescriptor[uint8]("uint8_3"),
-		data.NewNumericDescriptor[uint8]("uint8_4"),
-		data.NewNumericDescriptor[uint8]("uint8_5"),
-		data.NewNumericDescriptor[uint8]("uint8_6"),
-		data.NewNumericDescriptor[uint8]("uint8_7"),
-		data.NewNumericDescriptor[uint8]("uint8_8"),
-		data.NewNumericDescriptor[uint8]("uint8_9"),
-		data.NewNumericDescriptor[uint8]("uint8_10"),
+		data.NewNumericDescriptor[uint8]("uint8_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_7", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_8", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_9", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint8]("uint8_10", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	dataDecoder.SetDescriptor(18, data.Descriptor{
-		data.NewNumericDescriptor[uint64]("uint64_1"),
-		data.NewNumericDescriptor[int64]("int64_1"),
-		data.NewNumericDescriptor[float64]("float64_1"),
-		data.NewNumericDescriptor[uint64]("uint64_2"),
-		data.NewNumericDescriptor[int64]("int64_2"),
-		data.NewNumericDescriptor[float64]("float64_2"),
-		data.NewNumericDescriptor[uint64]("uint64_3"),
-		data.NewNumericDescriptor[int64]("int64_3"),
-		data.NewNumericDescriptor[float64]("float64_3"),
-		data.NewNumericDescriptor[uint64]("uint64_4"),
-		data.NewNumericDescriptor[int64]("int64_4"),
-		data.NewNumericDescriptor[float64]("float64_4"),
-		data.NewNumericDescriptor[uint64]("uint64_5"),
-		data.NewNumericDescriptor[int64]("int64_5"),
-		data.NewNumericDescriptor[float64]("float64_5"),
-		data.NewNumericDescriptor[uint64]("uint64_6"),
-		data.NewNumericDescriptor[int64]("int64_6"),
-		data.NewNumericDescriptor[float64]("float64_6"),
+		data.NewNumericDescriptor[uint64]("uint64_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_1", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_2", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_3", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_4", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_5", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[uint64]("uint64_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[int64]("int64_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
+		data.NewNumericDescriptor[float64]("float64_6", make(data.ConversionDescriptor, 0), make(data.ConversionDescriptor, 0)),
 	})
 	encoder.SetPacketEncoder(9, dataDecoder)
 	encoder.SetPacketEncoder(10, dataDecoder)


### PR DESCRIPTION
This PR implements the unit converter in the new transport logic. The new converter is embedded into the description of the measurements, applying conversions when decoding.

All the other code has been updated to take this into consideration