### PR TITLE
[backend] TCP connections not reconnecting after link goes down

### DIFF
--- a/backend/pkg/transport/network/tcp/client.go
+++ b/backend/pkg/transport/network/tcp/client.go
@@ -53,6 +53,8 @@ type ClientConfig struct {
 	CurrentRetries int
 	// Backoff specifies the backoff algorithm for this client
 	Backoff backoffFunction
+	// AbortOnError specifies whether the client should abort on errors or keep trying to connect
+	AbortOnError bool
 }
 
 // NewClient inits a ClientConfig with good defaults and the provided information
@@ -66,8 +68,9 @@ func NewClient(local net.Addr) ClientConfig {
 
 		Context: context.TODO(),
 
-		MaxRetries: -1,
-		Backoff:    NewExponBackoff(defaultBackoffMin, defaultBackoffExp, defaultBackoffMax),
+		MaxRetries:   -1,
+		Backoff:      NewExponBackoff(defaultBackoffMin, defaultBackoffExp, defaultBackoffMax),
+		AbortOnError: false,
 	}
 }
 

--- a/backend/pkg/transport/transport.go
+++ b/backend/pkg/transport/transport.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -83,6 +84,12 @@ func (transport *Transport) handleTCPConn(target abstraction.TransportTarget, co
 		return err
 	}
 
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		err := tcpConn.SetLinger(0)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error setting %s linger to zero: %v\n", target, err)
+		}
+	}
 	conn, errChan := tcp.WithErrChan(conn)
 	defer conn.Close()
 


### PR DESCRIPTION
The previous implementation had a bug where after connection to a board acting as server was lost the system will abort trying to connect due to how errors were handled, the new implementation should fix this