### PR TITLE
[backend] BLCU/boards logic

### DIFF
--- a/backend/pkg/abstraction/broker.go
+++ b/backend/pkg/abstraction/broker.go
@@ -32,7 +32,7 @@ type Broker interface {
 	SetAPI(BrokerAPI)
 }
 
-// BrokerAPi is the API provided for the Broker by the Vehicle.
+// BrokerAPI is the API provided for the Broker by the Vehicle.
 // The Broker must use this to communicate with the rest of the code
 type BrokerAPI interface {
 	// UserPush notifies that the front-end has sent information without a previous request

--- a/backend/pkg/blcu/blcu.go
+++ b/backend/pkg/blcu/blcu.go
@@ -2,6 +2,7 @@ package blcu
 
 import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	broker "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/blcu"
 )
 
 type BLCU struct {
@@ -11,5 +12,16 @@ type BLCU struct {
 func NewBLCU(boarMap map[string]abstraction.BoardId) *BLCU {
 	return &BLCU{
 		boardToId: boarMap,
+	}
+}
+
+func (blcu *BLCU) Request(request abstraction.BrokerRequest) (abstraction.BrokerResponse, error) {
+	switch request.Topic() {
+	case "blcu/download":
+		return broker.Download.Pull(request)
+	case "blcu/upload":
+		return broker.Upload.Pull(request)
+	default:
+		return nil, ErrTopicNotFound{}
 	}
 }

--- a/backend/pkg/blcu/blcu.go
+++ b/backend/pkg/blcu/blcu.go
@@ -1,0 +1,15 @@
+package blcu
+
+import (
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type BLCU struct {
+	boardToId map[string]abstraction.BoardId
+}
+
+func NewBLCU(boarMap map[string]abstraction.BoardId) *BLCU {
+	return &BLCU{
+		boardToId: boarMap,
+	}
+}

--- a/backend/pkg/blcu/blcu.go
+++ b/backend/pkg/blcu/blcu.go
@@ -3,6 +3,7 @@ package blcu
 import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 	broker "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/blcu"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport"
 )
 
 func Request(request abstraction.BrokerRequest) (abstraction.BrokerResponse, error) {
@@ -31,4 +32,14 @@ func SendPush(push abstraction.BrokerPush) error {
 			received: push.Topic(),
 		}
 	}
+}
+
+func SendMessage(message abstraction.TransportMessage) error {
+	err := transport.Transport.SendMessage(message)
+	if err != nil {
+		return ErrSendMessage{
+			received: message,
+		}
+	}
+	return nil
 }

--- a/backend/pkg/blcu/blcu.go
+++ b/backend/pkg/blcu/blcu.go
@@ -5,17 +5,7 @@ import (
 	broker "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/blcu"
 )
 
-type BLCU struct {
-	boardToId map[string]abstraction.BoardId
-}
-
-func NewBLCU(boarMap map[string]abstraction.BoardId) *BLCU {
-	return &BLCU{
-		boardToId: boarMap,
-	}
-}
-
-func (blcu *BLCU) Request(request abstraction.BrokerRequest) (abstraction.BrokerResponse, error) {
+func Request(request abstraction.BrokerRequest) (abstraction.BrokerResponse, error) {
 	switch request.Topic() {
 	case "blcu/download":
 		return broker.Download.Pull(request)
@@ -29,7 +19,7 @@ func (blcu *BLCU) Request(request abstraction.BrokerRequest) (abstraction.Broker
 	}
 }
 
-func (blcu *BLCU) SendPush(push abstraction.BrokerPush) error {
+func SendPush(push abstraction.BrokerPush) error {
 	switch push.Topic() {
 	case "blcu/download":
 		return broker.Download.Push(push)

--- a/backend/pkg/blcu/blcu.go
+++ b/backend/pkg/blcu/blcu.go
@@ -22,6 +22,23 @@ func (blcu *BLCU) Request(request abstraction.BrokerRequest) (abstraction.Broker
 	case "blcu/upload":
 		return broker.Upload.Pull(request)
 	default:
-		return nil, ErrTopicNotFound{}
+		return nil, ErrTopicNotFound{
+			expected: "blcu/download, blcu/upload",
+			received: request.Topic(),
+		}
+	}
+}
+
+func (blcu *BLCU) SendPush(push abstraction.BrokerPush) error {
+	switch push.Topic() {
+	case "blcu/download":
+		return broker.Download.Push(push)
+	case "blcu/upload":
+		return broker.Upload.Push(push)
+	default:
+		return ErrTopicNotFound{
+			expected: "blcu/download, blcu/upload",
+			received: push.Topic(),
+		}
 	}
 }

--- a/backend/pkg/blcu/errors.go
+++ b/backend/pkg/blcu/errors.go
@@ -1,0 +1,15 @@
+package blcu
+
+import (
+	"fmt"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+)
+
+type ErrTopicNotFound struct {
+	expected abstraction.BrokerTopic
+	received abstraction.BrokerTopic
+}
+
+func (err ErrTopicNotFound) Error() string {
+	return fmt.Sprintf("topic not found: got %s expected %s", err.received, err.expected)
+}

--- a/backend/pkg/blcu/errors.go
+++ b/backend/pkg/blcu/errors.go
@@ -13,3 +13,11 @@ type ErrTopicNotFound struct {
 func (err ErrTopicNotFound) Error() string {
 	return fmt.Sprintf("topic not found: got %s expected %s", err.received, err.expected)
 }
+
+type ErrSendMessage struct {
+	received abstraction.TransportMessage
+}
+
+func (err ErrSendMessage) Error() string {
+	return fmt.Sprintf("message not sent: got %s", err.received)
+}

--- a/backend/pkg/transport/packet/blcu/decoder.go
+++ b/backend/pkg/transport/packet/blcu/decoder.go
@@ -14,7 +14,7 @@ func NewDecoder() *Decoder {
 	return &Decoder{}
 }
 
-// Decode decodes the next packet on reader and returns the corresponding blcuAck.
+// Decode decodes the next packet on reader and returns the corresponding blcu Ack.
 func (decoder *Decoder) Decode(id abstraction.PacketId, reader io.Reader) (abstraction.Packet, error) {
 	return NewAck(id), nil
 }


### PR DESCRIPTION
The BLCU is the board in charge of transferring orders to the other boards in the vehicle, acting as a bridge between us and the pod. The logic from last year is being reused and integrated into this year's backend.

Resolves #35 