### PR TITLE
[ethernet-view] reset packet information when board reconnects

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -112,7 +112,15 @@ func main() {
 	}
 
 	// <--- update factory --->
-	updateFactory := update_factory.NewFactory()
+	boardToPacket := make(map[abstraction.TransportTarget][]uint16)
+	for _, board := range podData.Boards {
+		packetIds := make([]uint16, len(board.Packets))
+		for i, packet := range board.Packets {
+			packetIds[i] = packet.Id
+		}
+		boardToPacket[abstraction.TransportTarget(board.Name)] = packetIds
+	}
+	updateFactory := update_factory.NewFactory(boardToPacket)
 
 	// <--- logger --->
 	var boardMap map[abstraction.BoardId]string

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -112,15 +112,15 @@ func main() {
 	}
 
 	// <--- update factory --->
-	boardToPacket := make(map[abstraction.TransportTarget][]uint16)
+	boardToPackets := make(map[abstraction.TransportTarget][]uint16)
 	for _, board := range podData.Boards {
 		packetIds := make([]uint16, len(board.Packets))
 		for i, packet := range board.Packets {
 			packetIds[i] = packet.Id
 		}
-		boardToPacket[abstraction.TransportTarget(board.Name)] = packetIds
+		boardToPackets[abstraction.TransportTarget(board.Name)] = packetIds
 	}
-	updateFactory := update_factory.NewFactory(boardToPacket)
+	updateFactory := update_factory.NewFactory(boardToPackets)
 
 	// <--- logger --->
 	var boardMap map[abstraction.BoardId]string

--- a/backend/pkg/broker/topics/connection/update.go
+++ b/backend/pkg/broker/topics/connection/update.go
@@ -49,7 +49,9 @@ func (update *Update) Push(push abstraction.BrokerPush) error {
 	defer update.connectionMx.Unlock()
 	update.connections[connection.Name] = *connection
 
-	rawPayload, err := json.Marshal(update.connections)
+	rawPayload, err := json.Marshal(map[string]Connection{
+		connection.Name: *connection,
+	})
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/vehicle/vehicle.go
+++ b/backend/pkg/vehicle/vehicle.go
@@ -177,4 +177,7 @@ func (vehicle *Vehicle) SendPush(abstraction.BrokerPush) error {
 // ConnectionUpdate is the method invoked by transport to signal a connection state has changed
 func (vehicle *Vehicle) ConnectionUpdate(target abstraction.TransportTarget, isConnected bool) {
 	vehicle.broker.Push(connection_topic.NewConnection(string(target), isConnected))
+	if isConnected {
+		vehicle.updateFactory.ClearPacketsFor(target)
+	}
 }

--- a/common-front/lib/adapters/ConnectionUpdate.ts
+++ b/common-front/lib/adapters/ConnectionUpdate.ts
@@ -1,3 +1,3 @@
 import { Connection } from "../models";
 
-export type ConnectionsUpdate = Connection[];
+export type ConnectionsUpdate = {[name: string]: Connection};

--- a/common-front/lib/components/Connections/useConnections.ts
+++ b/common-front/lib/components/Connections/useConnections.ts
@@ -1,15 +1,20 @@
-import { useConnectionsStore, useSubscribe } from "../..";
+import { useConnectionsStore, useMeasurementsStore, usePodDataStore, useSubscribe } from "../..";
 
 export function useConnections() {
 
-    // const setBoardConnections = useStore(state => state.setConnections);
-    // const connections = useStore(state => state.connections);
-
-    const setBoardConnections = useConnectionsStore(state => state.setConnections);
+    const setBoardConnections = useConnectionsStore(state => state.setConnections)
+    const clearMeasurements = useMeasurementsStore(state => state.clearMeasurements)
+    const clearPodData = usePodDataStore(state => state.clearPodData);
     const connections = useConnectionsStore(state => state.connections)
 
     useSubscribe("connection/update", (update) => {
         setBoardConnections(update)
+        for (const connection of Object.values(update)) {
+            if (connection.isConnected) {
+                clearMeasurements(connection.name)
+                clearPodData(connection.name)
+            }
+        }
     });
 
     return connections;

--- a/common-front/lib/store/measurementsStore.ts
+++ b/common-front/lib/store/measurementsStore.ts
@@ -8,6 +8,7 @@ import {
     PacketUpdate,
 } from "../adapters";
 import { create } from "zustand";
+import { isNumericType } from "../BackendTypes";
 
 export type Measurements = Record<string, Measurement>
 
@@ -15,7 +16,8 @@ export interface MeasurementsStore {
     measurements: Measurements;
     packetIdToBoard: Record<number, string>;
     initMeasurements: (podDataAdapter: PodDataAdapter) => void;
-    updateMeasurements: (measurements: Record<string, PacketUpdate>) => void
+    updateMeasurements: (measurements: Record<string, PacketUpdate>) => void;
+    clearMeasurements: (board: string) => void
 }
 
 export const useMeasurementsStore = create<MeasurementsStore>((set, get) => ({
@@ -57,6 +59,31 @@ export const useMeasurementsStore = create<MeasurementsStore>((set, get) => ({
                 measurementsDraft[measurementId].value = mUpdate;
             }
         }
+        
+        set(state => ({
+            ...state,
+            measurements: measurementsDraft
+        }))
+    },
+
+    clearMeasurements: (board: string) => {
+        const measurementsDraft = get().measurements;
+
+        for (const measurementId in measurementsDraft) {
+            if (measurementId.includes(board)) {
+                if (isNumericType(measurementsDraft[measurementId].type)) {
+                    measurementsDraft[measurementId].value = {
+                        average: 0,
+                        last: 0,
+                    }
+                } else if (measurementsDraft[measurementId].type == "bool") {
+                    measurementsDraft[measurementId].value = false
+                } else {
+                    measurementsDraft[measurementId].value = "Default"
+                }
+            }
+        }
+
         set(state => ({
             ...state,
             measurements: measurementsDraft


### PR DESCRIPTION
Under request from firmware, the values of packets reset when a board reconnects.

The backend now just resets the values on the update factory and on the frontend the stores get updated when receiving a notification from the backend.

To make the change work, the logic of the update topic had to be changed because before all connection statuses would be sent when a connection got updated and now instead just the updated connection gets broadcasted. This logic made it a pain to detect changes on the frontend, so this new logic simplifies that. 