### PR TITLE
[ethernet-view] Switch between showing latest and average value

### DIFF
--- a/common-front/lib/adapters/PodData.ts
+++ b/common-front/lib/adapters/PodData.ts
@@ -6,17 +6,17 @@ import {
     EnumMeasurement,
     Measurement,
     NumericMeasurement,
-} from "../models";
+} from '../models';
 
-import { NumericType, isNumericType } from "../BackendTypes";
+import { NumericType, isNumericType } from '../BackendTypes';
 
 export type PodDataAdapter = { boards: { [name: string]: BoardAdapter } };
 
-type BoardAdapter = Omit<Board, "measurementToPacket" | "packets"> & {
+type BoardAdapter = Omit<Board, 'measurementToPacket' | 'packets'> & {
     packets: { [id: number]: PacketAdapter };
 };
 
-export type PacketAdapter = Omit<Packet, "measurements"> & {
+export type PacketAdapter = Omit<Packet, 'measurements'> & {
     measurements: { [name: string]: MeasurementAdapter };
 };
 
@@ -25,9 +25,9 @@ export type MeasurementAdapter =
     | BooleanMeasurementAdapter
     | EnumMeasurementAdapter;
 
-export type NumericMeasurementAdapter = Omit<NumericMeasurement, "value">;
-export type BooleanMeasurementAdapter = Omit<BooleanMeasurement, "value">;
-export type EnumMeasurementAdapter = Omit<EnumMeasurement, "value">;
+export type NumericMeasurementAdapter = Omit<NumericMeasurement, 'value'>;
+export type BooleanMeasurementAdapter = Omit<BooleanMeasurement, 'value'>;
+export type EnumMeasurementAdapter = Omit<EnumMeasurement, 'value'>;
 
 export function createPodDataFromAdapter(adapter: PodDataAdapter): PodData {
     const boards: Board[] = Object.values(adapter.boards).map(
@@ -73,7 +73,7 @@ function getMeasurements(
         const id = `${boardName}/${adapter.id}`;
         if (isNumericAdapter(adapter)) {
             return getNumericMeasurement(id, adapter);
-        } else if (adapter.type == "enum") {
+        } else if (adapter.type == 'enum') {
             return getEnumMeasurement(id, adapter);
         } else {
             return getBooleanMeasurement(id, adapter);
@@ -101,6 +101,7 @@ export function getNumericMeasurement(
         value: {
             average: 0,
             last: 0,
+            showLatest: false,
         },
         units: adapter.units,
         safeRange: adapter.safeRange,
@@ -115,8 +116,8 @@ export function getEnumMeasurement(
     return {
         id: id,
         name: adapter.name,
-        type: "enum",
-        value: "Default",
+        type: 'enum',
+        value: 'Default',
     };
 }
 
@@ -127,7 +128,7 @@ export function getBooleanMeasurement(
     return {
         id: id,
         name: adapter.name,
-        type: adapter.type as "bool",
+        type: adapter.type as 'bool',
         value: false,
     };
 }
@@ -147,7 +148,7 @@ export function getBooleanMeasurement(
 export function getPacketToBoard(
     boards: Record<string, BoardAdapter>
 ): Record<number, number> {
-    let packetToBoard: PodData["packetToBoard"] = {};
+    let packetToBoard: PodData['packetToBoard'] = {};
 
     Object.values(boards).forEach((board, index) => {
         Object.values(board.packets).forEach((packet) => {
@@ -161,7 +162,7 @@ export function getPacketToBoard(
 export function getMeasurementToPacket(
     packets: Record<string, PacketAdapter>
 ): Record<string, number> {
-    let measurementToPacket: Board["measurementToPacket"] = {};
+    let measurementToPacket: Board['measurementToPacket'] = {};
 
     Object.values(packets).forEach((packet) => {
         Object.values(packet.measurements).forEach(

--- a/common-front/lib/models/PodData/Measurement.ts
+++ b/common-front/lib/models/PodData/Measurement.ts
@@ -1,4 +1,4 @@
-import { NumericType, isNumericType } from "../../BackendTypes";
+import { NumericType, isNumericType } from '../../BackendTypes';
 
 export type Measurement =
     | NumericMeasurement
@@ -19,15 +19,19 @@ export type NumericMeasurement = AbstractMeasurement & {
     warningRange: [number | null, number | null];
 };
 
-export type NumericValue = { last: number; average: number };
+export type NumericValue = {
+    last: number;
+    average: number;
+    showLatest: boolean;
+};
 
 export type BooleanMeasurement = AbstractMeasurement & {
-    type: "bool";
+    type: 'bool';
     value: boolean;
 };
 
 export type EnumMeasurement = AbstractMeasurement & {
-    type: "enum";
+    type: 'enum';
     value: string;
 };
 
@@ -67,16 +71,16 @@ export function isNumericMeasurement(
 
 export function isNumber(type: string) {
     switch (type) {
-        case "uint8":
-        case "uint16":
-        case "uint32":
-        case "uint64":
-        case "int8":
-        case "int16":
-        case "int32":
-        case "int64":
-        case "float32":
-        case "float64":
+        case 'uint8':
+        case 'uint16':
+        case 'uint32':
+        case 'uint64':
+        case 'int8':
+        case 'int16':
+        case 'int32':
+        case 'int64':
+        case 'float32':
+        case 'float64':
             return true;
         default:
             return false;
@@ -85,20 +89,20 @@ export function isNumber(type: string) {
 
 export function getNumber(type: string, value: string): number {
     switch (type) {
-        case "uint8":
-        case "uint16":
-        case "uint32":
-        case "uint64":
-        case "int8":
-        case "int16":
-        case "int32":
-        case "int64":
+        case 'uint8':
+        case 'uint16':
+        case 'uint32':
+        case 'uint64':
+        case 'int8':
+        case 'int16':
+        case 'int32':
+        case 'int64':
             return Number.parseInt(value);
-        case "float32":
-        case "float64":
+        case 'float32':
+        case 'float64':
             return Number.parseFloat(value);
         default:
-            console.error("Incorrect value type");
-            throw "Incorrect value type";
+            console.error('Incorrect value type');
+            throw 'Incorrect value type';
     }
 }

--- a/common-front/lib/store/measurementsStore.ts
+++ b/common-front/lib/store/measurementsStore.ts
@@ -1,4 +1,8 @@
-import { Measurement, NumericMeasurement, isNumericMeasurement } from "../models";
+import {
+    Measurement,
+    NumericMeasurement,
+    isNumericMeasurement,
+} from '../models';
 import {
     getBooleanMeasurement,
     getEnumMeasurement,
@@ -6,30 +10,32 @@ import {
     isNumericAdapter,
     PodDataAdapter,
     PacketUpdate,
-} from "../adapters";
-import { create } from "zustand";
-import { isNumericType } from "../BackendTypes";
+} from '../adapters';
+import { create } from 'zustand';
+import { isNumericType } from '../BackendTypes';
+import { NumericValue } from '../models/PodData/Measurement';
 
-export type Measurements = Record<string, Measurement>
+export type Measurements = Record<string, Measurement>;
 export type MeasurementId = string;
 export type MeasurementName = string;
 export type MeasurementColor = string;
 export type MeasurementUnits = string;
 export type UpdateFunction = () => number;
 export type NumericMeasurementInfo = {
-  readonly id: MeasurementId;
-  readonly name: MeasurementName;
-  readonly range: [number | null, number | null];
-  readonly color: MeasurementColor;
-  readonly units: MeasurementUnits;
-  readonly getUpdate: UpdateFunction;
+    readonly id: MeasurementId;
+    readonly name: MeasurementName;
+    readonly range: [number | null, number | null];
+    readonly color: MeasurementColor;
+    readonly units: MeasurementUnits;
+    readonly getUpdate: UpdateFunction;
 };
 
 export interface MeasurementsStore {
     measurements: Measurements;
     packetIdToBoard: Record<number, string>;
     initMeasurements: (podDataAdapter: PodDataAdapter) => void;
-    updateMeasurements: (measurements: Record<string, PacketUpdate>) => void
+    updateMeasurements: (measurements: Record<string, PacketUpdate>) => void;
+    showMeasurementLatest: (id: string, showLatest: boolean) => void;
     getMeasurement: (id: MeasurementId) => Measurement;
     getNumericMeasurementInfo: (id: MeasurementId) => NumericMeasurementInfo;
     getMeasurementFallback: (id: MeasurementId) => Measurement;
@@ -43,43 +49,53 @@ export const useMeasurementsStore = create<MeasurementsStore>((set, get) => ({
     /**
      * Reducer that receives a PodDataAdapter and initializes the measurements
      * and packetIdToBoard map in state.
-     * @param {PodDataAdapter} podDataAdapter 
+     * @param {PodDataAdapter} podDataAdapter
      * @returns {Measurements}
      */
     initMeasurements: (podDataAdapter: PodDataAdapter) => {
-        set(state => ({
+        set((state) => ({
             ...state,
             measurements: createMeasurementsFromPodDataAdapter(podDataAdapter),
             packetIdToBoard: getPacketIdToBoard(podDataAdapter),
-        }))
+        }));
     },
 
     /**
      * Reducer that updates the measurements in the state.
      * It receives a measurements map with PacketUpdates, extract the measurements
      * from each of them and updates the measurements.
-     * @param {Record<string, PacketUpdate>} measurements 
+     * @param {Record<string, PacketUpdate>} measurements
      */
     updateMeasurements: (measurements: Record<string, PacketUpdate>) => {
-
         const measurementsDraft = get().measurements;
 
-        for(const update of Object.values(measurements)) {
-            for (const [id, mUpdate] of Object.entries(update.measurementUpdates)) {
+        for (const update of Object.values(measurements)) {
+            for (const [id, mUpdate] of Object.entries(
+                update.measurementUpdates
+            )) {
                 const boardName = get().packetIdToBoard[update.id];
                 if (!boardName) {
                     continue;
                 }
 
                 const measurementId = `${boardName}/${id}`;
-                measurementsDraft[measurementId].value = mUpdate;
+                if (typeof mUpdate != 'string' && typeof mUpdate != 'boolean') {
+                    (
+                        measurementsDraft[measurementId].value as NumericValue
+                    ).last = mUpdate.last;
+                    (
+                        measurementsDraft[measurementId].value as NumericValue
+                    ).average = mUpdate.average;
+                } else {
+                    measurementsDraft[measurementId].value = mUpdate;
+                }
             }
         }
-        
-        set(state => ({
+
+        set((state) => ({
             ...state,
-            measurements: measurementsDraft
-        }))
+            measurements: measurementsDraft,
+        }));
     },
 
     clearMeasurements: (board: string) => {
@@ -91,19 +107,39 @@ export const useMeasurementsStore = create<MeasurementsStore>((set, get) => ({
                     measurementsDraft[measurementId].value = {
                         average: 0,
                         last: 0,
-                    }
-                } else if (measurementsDraft[measurementId].type == "bool") {
-                    measurementsDraft[measurementId].value = false
+                        showLatest: false,
+                    };
+                } else if (measurementsDraft[measurementId].type == 'bool') {
+                    measurementsDraft[measurementId].value = false;
                 } else {
-                    measurementsDraft[measurementId].value = "Default"
+                    measurementsDraft[measurementId].value = 'Default';
                 }
             }
         }
 
-        set(state => ({
+        set((state) => ({
             ...state,
-            measurements: measurementsDraft
-        }))
+            measurements: measurementsDraft,
+        }));
+    },
+
+    showMeasurementLatest: (id: string, showLatest: boolean) => {
+        set((state) => {
+            const draft = state.measurements;
+
+            if (
+                id in draft &&
+                typeof draft[id].value != 'string' &&
+                typeof draft[id].value != 'boolean'
+            ) {
+                (draft[id].value as NumericValue).showLatest = showLatest;
+            }
+
+            return {
+                ...state,
+                measurements: draft,
+            };
+        });
     },
 
     getMeasurement: (id: string) => {
@@ -127,17 +163,19 @@ export const useMeasurementsStore = create<MeasurementsStore>((set, get) => ({
     },
 
     getMeasurementFallback: (id: string) => {
-        return get().measurements[id] ?? {
-            id: "Default",
-            name: "Default",
-            safeRange: [null, null],
-            warningRange: [null, null],
-            type: "uint8",
-            units: "A",
-            value: { average: 0, last: 0 },
-        };
-    }
-}))
+        return (
+            get().measurements[id] ?? {
+                id: 'Default',
+                name: 'Default',
+                safeRange: [null, null],
+                warningRange: [null, null],
+                type: 'uint8',
+                units: 'A',
+                value: { average: 0, last: 0 },
+            }
+        );
+    },
+}));
 
 function createMeasurementsFromPodDataAdapter(
     podDataAdapter: PodDataAdapter
@@ -150,7 +188,7 @@ function createMeasurementsFromPodDataAdapter(
                 const id = `${board.name}/${adapter.id}`;
                 if (isNumericAdapter(adapter)) {
                     measurements[id] = getNumericMeasurement(id, adapter);
-                } else if (adapter.type == "bool") {
+                } else if (adapter.type == 'bool') {
                     measurements[id] = getBooleanMeasurement(id, adapter);
                 } else {
                     measurements[id] = getEnumMeasurement(id, adapter);

--- a/ethernet-view/src/components/ReceiveTable/BoardView/PacketView/MeasurementView/MeasurementView.module.scss
+++ b/ethernet-view/src/components/ReceiveTable/BoardView/PacketView/MeasurementView/MeasurementView.module.scss
@@ -22,8 +22,12 @@
     color: rgb(78, 78, 78);
 }
 
-.value {
+.show_last {
     grid-column: 2;
+}
+
+.value {
+    grid-column: 3;
     text-align: right;
     color: hsl(29, 88%, 57%);
     font-family: Consolas;
@@ -31,11 +35,11 @@
 }
 
 .units {
-    grid-column: 3;
+    grid-column: 4;
     text-align: center;
 }
 
 .type {
-    grid-column: 4;
+    grid-column: 5;
     text-align: center;
 }

--- a/ethernet-view/src/components/ReceiveTable/BoardView/PacketView/MeasurementView/MeasurementView.tsx
+++ b/ethernet-view/src/components/ReceiveTable/BoardView/PacketView/MeasurementView/MeasurementView.tsx
@@ -1,40 +1,56 @@
-import styles from "./MeasurementView.module.scss";
-import { Measurement, isNumericMeasurement } from "common";
-import { useUpdater } from "./useUpdater";
+import styles from './MeasurementView.module.scss';
+import {
+    Measurement,
+    isNumericMeasurement,
+    useMeasurementsStore,
+} from 'common';
+import { useUpdater } from './useUpdater';
+import { FormEvent } from 'react';
 
 type Props = {
     measurement: Measurement;
 };
 
 export const MeasurementView = ({ measurement }: Props) => {
+    const setShowMeasurementLatest = useMeasurementsStore(
+        (state) => (showLatest: boolean) =>
+            state.showMeasurementLatest(measurement.id, showLatest)
+    );
     const isNumeric = isNumericMeasurement(measurement);
 
     const { valueRef } = useUpdater(
         measurement.id,
         isNumeric
-            ? measurement.value.average.toFixed(3)
+            ? measurement.value.showLatest
+                ? measurement.value.last.toFixed(3)
+                : measurement.value.average.toFixed(3)
             : measurement.value.toString()
     );
+
+    const onLatestValueChange = (event: FormEvent<HTMLInputElement>) => {
+        setShowMeasurementLatest(event.currentTarget.checked);
+    };
 
     return (
         <>
             <span className={styles.name}>{measurement.name}</span>
             {isNumeric && (
                 <>
-                    <span
-                        ref={valueRef}
-                        className={styles.value}
-                    ></span>
+                    <input
+                        type="checkbox"
+                        defaultChecked={false}
+                        className={styles.show_last}
+                        title="Show latest value"
+                        onInput={onLatestValueChange}
+                    />
+                    <span ref={valueRef} className={styles.value}></span>
                     <span className={styles.units}>{measurement.units}</span>
                     <span className={styles.type}>{measurement.type}</span>
                 </>
             )}
             {!isNumeric && (
                 <>
-                    <span
-                        ref={valueRef}
-                        className={styles.value}
-                    ></span>
+                    <span ref={valueRef} className={styles.value}></span>
                     <span className={styles.type}>{measurement.type}</span>
                 </>
             )}

--- a/ethernet-view/src/components/ReceiveTable/TableUpdater.tsx
+++ b/ethernet-view/src/components/ReceiveTable/TableUpdater.tsx
@@ -4,8 +4,8 @@ import {
     useGlobalTicker,
     useMeasurementsStore,
     usePodDataStore,
-} from "common";
-import { createContext, useRef } from "react";
+} from 'common';
+import { createContext, useRef } from 'react';
 
 export type PacketElement = {
     count: Text;
@@ -36,11 +36,12 @@ export const TableUpdater = ({ children }: Props) => {
     const packetElements = useRef<Record<string, PacketElement>>({});
     const measurementElements = useRef<MeasurementElement[]>([]);
 
-    const podData = usePodDataStore(state => state.podData)
-    const getMeasurement = useMeasurementsStore(state => state.getMeasurement)
+    const podData = usePodDataStore((state) => state.podData);
+    const getMeasurement = useMeasurementsStore(
+        (state) => state.getMeasurement
+    );
 
     useGlobalTicker(() => {
-        
         for (const id in packetElements.current) {
             const packet = getPacket(podData, Number.parseInt(id));
             const element = packetElements.current[id];
@@ -66,7 +67,9 @@ export const TableUpdater = ({ children }: Props) => {
                 return;
             }
             element.value.nodeValue = isNumericMeasurement(measurement)
-                ? measurement.value.average.toFixed(3)
+                ? measurement.value.showLatest
+                    ? measurement.value.last.toFixed(3)
+                    : measurement.value.average.toFixed(3)
                 : measurement.value.toString();
         }
     });


### PR DESCRIPTION
Previously the measurement table only showed the moving average of the numerical values. For some values this does not make sense, so there is now a checkbox to either show the latest or the average. The default is still the average.

The change was simple because both values were being sent already to the frontend.