### PR TITLE
[backend] Logger Hotfix

### DIFF
--- a/backend/pkg/logger/data/logger.go
+++ b/backend/pkg/logger/data/logger.go
@@ -106,8 +106,8 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 			val = string(v.Variant())
 		}
 
-		file, ok := sublogger.valueFileSlice[valueName]
-		if !ok {
+		file, exists := sublogger.valueFileSlice[valueName]
+		if !exists {
 			filename := path.Join(
 				"logger/data",
 				fmt.Sprintf("data_%s", loggerHandler.Timestamp.Format(time.RFC3339)),


### PR DESCRIPTION
This hotfix solves a variable shadowing in the data sublogger that prevented new files from being created. The file-existence check was obscured by a previous check, making the check's output always 'true', meaning the file was expected to exist when it didn't.