### PR TITLE
Fix logger file naming and close procedures

### DIFF
--- a/backend/pkg/logger/data/logger.go
+++ b/backend/pkg/logger/data/logger.go
@@ -106,8 +106,8 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 			val = string(v.Variant())
 		}
 
-		file, exists := sublogger.valueFileSlice[valueName]
-		if !exists {
+		file, ok := sublogger.valueFileSlice[valueName]
+		if !ok {
 			filename := path.Join(
 				"logger/data",
 				fmt.Sprintf("data_%s", loggerHandler.Timestamp.Format(time.RFC3339)),
@@ -147,6 +147,7 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 				Timestamp: time.Now(),
 				Inner:     err,
 			}
+			fmt.Println(writerErr)
 		}
 		writer.Flush()
 	}
@@ -164,7 +165,7 @@ func (sublogger *Logger) Stop() error {
 	}
 
 	closeErr := error(nil)
-	for _, file := range sublogger.valueFileSlice {
+	for value, file := range sublogger.valueFileSlice {
 		err := file.Close()
 		if err != nil {
 			closeErr = loggerHandler.ErrClosingFile{
@@ -172,9 +173,11 @@ func (sublogger *Logger) Stop() error {
 				Timestamp: time.Now(),
 			}
 
-			fmt.Println(closeErr.Error())
+			fmt.Println(value, ": ", closeErr)
 		}
 	}
+
+	sublogger.valueFileSlice = make(map[data.ValueName]io.WriteCloser, len(sublogger.valueFileSlice))
 
 	fmt.Println("Logger stopped")
 	return closeErr

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -61,6 +61,8 @@ func (logger *Logger) Start() error {
 		return nil
 	}
 
+	Timestamp = time.Now()
+
 	// Create log folders
 	for subLogger := range logger.subloggers {
 		loggerPath := path.Join("logger", string(subLogger), Timestamp.Format(time.RFC3339))

--- a/backend/pkg/logger/protection/logger.go
+++ b/backend/pkg/logger/protection/logger.go
@@ -158,6 +158,8 @@ func (sublogger *Logger) Stop() error {
 		}
 	}
 
+	sublogger.infoIdMap = make(map[abstraction.BoardId]io.WriteCloser, len(sublogger.infoIdMap))
+
 	fmt.Println("Logger stopped")
 	return closeErr
 }


### PR DESCRIPTION
There were two bugs in the logger:

* The log timestamp was just set the first time the app runs, meaning consecutive logs without reloading overwrite the previous one, now the timestamp gets calculated every time the start mehtod is invoked
* The data and proteciton subloggers didn't clear the file map, this meant that the logs were being written to an already closed file because upon reading the map, an entry already existed, but that entry was closed. 