### PR TITLE
Logger Timestamp Format Hotfix

### DIFF
--- a/backend/pkg/logger/data/logger.go
+++ b/backend/pkg/logger/data/logger.go
@@ -110,7 +110,7 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 		if !ok {
 			filename := path.Join(
 				"logger/data",
-				fmt.Sprintf("data_%s", loggerHandler.Timestamp.Format(time.RFC3339)),
+				fmt.Sprintf("data_%s_%s", timestamp.Format("YYYY_MM_DD_HH_mm_ss"), fmt.Sprint(timestamp.Nanosecond())),
 				fmt.Sprintf("%s.csv", valueName),
 			)
 			err := os.MkdirAll(path.Dir(filename), os.ModePerm)

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -21,7 +21,7 @@ type Logger struct {
 	// An atomic boolean is used in order to use CompareAndSwap in the Start and Stop methods
 	running        *atomic.Bool
 	subloggersLock *sync.RWMutex
-	// The subloggers are only the loggers selected at the start of the log
+	// The subloggers are only the logger s selected at the start of the log
 	subloggers map[abstraction.LoggerName]abstraction.Logger
 
 	trace zerolog.Logger

--- a/backend/pkg/logger/logger.go
+++ b/backend/pkg/logger/logger.go
@@ -21,7 +21,7 @@ type Logger struct {
 	// An atomic boolean is used in order to use CompareAndSwap in the Start and Stop methods
 	running        *atomic.Bool
 	subloggersLock *sync.RWMutex
-	// The subloggers are only the logger s selected at the start of the log
+	// The subloggers are only the loggers selected at the start of the log
 	subloggers map[abstraction.LoggerName]abstraction.Logger
 
 	trace zerolog.Logger

--- a/backend/pkg/logger/order/logger.go
+++ b/backend/pkg/logger/order/logger.go
@@ -53,7 +53,7 @@ func (sublogger *Logger) Start() error {
 
 	filename := path.Join(
 		"logger/order",
-		fmt.Sprintf("order_%s", logger.Timestamp.Format(time.RFC3339)),
+		fmt.Sprintf("order_%s_%s", logger.Timestamp.Format("YYYY_MM_DD_HH_mm_ss"), fmt.Sprint(logger.Timestamp.Nanosecond())),
 		"order.csv",
 	)
 	err := os.MkdirAll(path.Dir(filename), os.ModePerm)

--- a/backend/pkg/logger/protection/logger.go
+++ b/backend/pkg/logger/protection/logger.go
@@ -92,7 +92,7 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 
 		filename := path.Join(
 			"logger/protections",
-			fmt.Sprintf("protections_%s", logger.Timestamp.Format(time.RFC3339)),
+			fmt.Sprintf("protection_%s_%s", logger.Timestamp.Format("YYYY_MM_DD_HH_mm_ss"), fmt.Sprint(logger.Timestamp.Nanosecond())),
 			fmt.Sprintf("%s.csv", boardName),
 		)
 		err := os.MkdirAll(path.Dir(filename), os.ModePerm)

--- a/backend/pkg/logger/state/logger.go
+++ b/backend/pkg/logger/state/logger.go
@@ -69,8 +69,8 @@ func (sublogger *Logger) PushRecord(record abstraction.LoggerRecord) error {
 
 	filename := path.Join(
 		"logger/state",
-		fmt.Sprintf("state_%s", logger.Timestamp.Format(time.RFC3339)),
-		fmt.Sprintf("state_%s.csv", time.Now().Format(time.RFC3339)),
+		fmt.Sprintf("data_%s_%s", logger.Timestamp.Format("YYYY_MM_DD_HH_mm_ss"), fmt.Sprint(logger.Timestamp.Nanosecond())),
+		fmt.Sprintf("state_%s_%s.csv", time.Now().Format("YYYY_MM_DD_HH_mm_ss"), fmt.Sprint(logger.Timestamp.Nanosecond())),
 	)
 	err := os.MkdirAll(path.Dir(filename), os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
This hotfix changes the timestamp format on the filenames from RFC3339 to "YYYY_MM_DD_HH_mm_ss_nano".