### PR TITLE
[backend][PR 3] Unit Tests / Add startServer function

### DIFF
--- a/backend/pkg/broker/topics/connection/connection_test.go
+++ b/backend/pkg/broker/topics/connection/connection_test.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker"
 	data "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/connection"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/tests_functions"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/websocket"
 	ws "github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"net/http"
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -16,40 +15,8 @@ import (
 
 func TestConnectionTopic_Push(t *testing.T) {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
-	u := url.URL{Scheme: "ws", Host: "localhost:8080", Path: "/connection"}
 	clientChan := make(chan *websocket.Client)
-
-	// Start HTTP server with WebSocket upgrade and echo back
-	http.HandleFunc("/connection", func(writer http.ResponseWriter, request *http.Request) {
-		upgrader := ws.Upgrader{
-			CheckOrigin: func(r *http.Request) bool { return true },
-		}
-		conn, upgradeErr := upgrader.Upgrade(writer, request, nil)
-		if upgradeErr != nil {
-			logger.Error().Err(upgradeErr).Msg("Failed to upgrade")
-			return
-		}
-		defer conn.Close()
-		defer logger.Info().Str("id", "server").Msg("Connection closed")
-
-		// Handle and echo messages continuously
-		go func() {
-			for {
-				_, msg, readMsgErr := conn.ReadMessage()
-				if readMsgErr != nil {
-					logger.Error().Err(readMsgErr).Msg("Read error")
-					return
-				}
-				readMsgErr = conn.WriteMessage(ws.TextMessage, msg)
-				if readMsgErr != nil {
-					logger.Error().Err(readMsgErr).Msg("Write error")
-					return
-				}
-			}
-		}()
-	})
-
-	go http.ListenAndServe(":8080", nil)
+	u := tests_functions.StartServer(logger, "connection")
 
 	// Set up the client
 	c, _, clientErr := ws.DefaultDialer.Dial(u.String(), nil)
@@ -107,40 +74,8 @@ func TestConnectionTopic_Push(t *testing.T) {
 
 func TestConnectionTopic_ClientMessage(t *testing.T) {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
-	u := url.URL{Scheme: "ws", Host: "localhost:8080", Path: "/connectioncm"}
 	clientChan := make(chan *websocket.Client)
-
-	// Start HTTP server with WebSocket upgrade and echo back
-	http.HandleFunc("/connectioncm", func(writer http.ResponseWriter, request *http.Request) {
-		upgrader := ws.Upgrader{
-			CheckOrigin: func(r *http.Request) bool { return true },
-		}
-		conn, upgradeErr := upgrader.Upgrade(writer, request, nil)
-		if upgradeErr != nil {
-			logger.Error().Err(upgradeErr).Msg("Failed to upgrade")
-			return
-		}
-		defer conn.Close()
-		defer logger.Info().Str("id", "server").Msg("Connection closed")
-
-		// Handle and echo messages continuously
-		go func() {
-			for {
-				_, msg, readMsgErr := conn.ReadMessage()
-				if readMsgErr != nil {
-					logger.Error().Err(readMsgErr).Msg("Read error")
-					return
-				}
-				readMsgErr = conn.WriteMessage(ws.TextMessage, msg)
-				if readMsgErr != nil {
-					logger.Error().Err(readMsgErr).Msg("Write error")
-					return
-				}
-			}
-		}()
-	})
-
-	go http.ListenAndServe(":8080", nil)
+	u := tests_functions.StartServer(logger, "conncetioncm")
 
 	// Set up the client
 	c, _, clientErr := ws.DefaultDialer.Dial(u.String(), nil)

--- a/backend/pkg/broker/topics/data/data_test.go
+++ b/backend/pkg/broker/topics/data/data_test.go
@@ -5,11 +5,10 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/internal/update_factory/models"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/data"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/tests_functions"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/websocket"
 	ws "github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"net/http"
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -17,40 +16,8 @@ import (
 
 func TestDataTopic_Push(t *testing.T) {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
-	u := url.URL{Scheme: "ws", Host: "localhost:8080", Path: "/data"}
 	clientChan := make(chan *websocket.Client)
-
-	// Start HTTP server with WebSocket upgrade and echo back
-	http.HandleFunc("/data", func(writer http.ResponseWriter, request *http.Request) {
-		upgrader := ws.Upgrader{
-			CheckOrigin: func(r *http.Request) bool { return true },
-		}
-		conn, upgradeErr := upgrader.Upgrade(writer, request, nil)
-		if upgradeErr != nil {
-			logger.Error().Err(upgradeErr).Msg("Failed to upgrade")
-			return
-		}
-		defer conn.Close()
-		defer logger.Info().Str("id", "server").Msg("Connection closed")
-
-		// Handle and echo messages continuously
-		go func() {
-			for {
-				_, msg, readMsgErr := conn.ReadMessage()
-				if readMsgErr != nil {
-					logger.Error().Err(readMsgErr).Msg("Read error")
-					return
-				}
-				readMsgErr = conn.WriteMessage(ws.TextMessage, msg)
-				if readMsgErr != nil {
-					logger.Error().Err(readMsgErr).Msg("Write error")
-					return
-				}
-			}
-		}()
-	})
-
-	go http.ListenAndServe(":8080", nil)
+	u := tests_functions.StartServer(logger, "data")
 
 	// Set up the client
 	c, _, clientErr := ws.DefaultDialer.Dial(u.String(), nil)

--- a/backend/pkg/broker/topics/message/message_test.go
+++ b/backend/pkg/broker/topics/message/message_test.go
@@ -5,12 +5,11 @@ import (
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker"
 	data "github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/message"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics/tests_functions"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/protection"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/websocket"
 	ws "github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"net/http"
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -18,40 +17,8 @@ import (
 
 func TestMessageTopic_Push(t *testing.T) {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
-	u := url.URL{Scheme: "ws", Host: "localhost:8080", Path: "/message"}
 	clientChan := make(chan *websocket.Client)
-
-	// Start HTTP server with WebSocket upgrade and echo back
-	http.HandleFunc("/message", func(writer http.ResponseWriter, request *http.Request) {
-		upgrader := ws.Upgrader{
-			CheckOrigin: func(r *http.Request) bool { return true },
-		}
-		conn, upgradeErr := upgrader.Upgrade(writer, request, nil)
-		if upgradeErr != nil {
-			logger.Error().Err(upgradeErr).Msg("Failed to upgrade")
-			return
-		}
-		defer conn.Close()
-		defer logger.Info().Str("id", "server").Msg("Connection closed")
-
-		// Handle and echo messages continuously
-		go func() {
-			for {
-				_, msg, readMsgRead := conn.ReadMessage()
-				if readMsgRead != nil {
-					logger.Error().Err(readMsgRead).Msg("Read error")
-					return
-				}
-				writeMsgErr := conn.WriteMessage(ws.TextMessage, msg)
-				if writeMsgErr != nil {
-					logger.Error().Err(writeMsgErr).Msg("Write error")
-					return
-				}
-			}
-		}()
-	})
-
-	go http.ListenAndServe(":8080", nil)
+	u := tests_functions.StartServer(logger, "message")
 
 	// Set up the client
 	c, _, err := ws.DefaultDialer.Dial(u.String(), nil)

--- a/backend/pkg/broker/topics/tests_functions/tests_functions.go
+++ b/backend/pkg/broker/topics/tests_functions/tests_functions.go
@@ -1,0 +1,47 @@
+package tests_functions
+
+import (
+	"fmt"
+	ws "github.com/gorilla/websocket"
+	"github.com/rs/zerolog"
+	"net/http"
+	"net/url"
+)
+
+func StartServer(logger zerolog.Logger, name string) url.URL {
+	u := url.URL{Scheme: "ws", Host: "localhost:8080", Path: fmt.Sprintf("/%s", name)}
+
+	// Start HTTP server with WebSocket upgrade and echo back
+	http.HandleFunc(fmt.Sprintf("/%s", name), func(writer http.ResponseWriter, request *http.Request) {
+		upgrader := ws.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		}
+		conn, upgradeErr := upgrader.Upgrade(writer, request, nil)
+		if upgradeErr != nil {
+			logger.Error().Err(upgradeErr).Msg("Failed to upgrade")
+			return
+		}
+		defer conn.Close()
+		defer logger.Info().Str("id", "server").Msg("Connection closed")
+
+		// Handle and echo messages continuously
+		go func() {
+			for {
+				_, msg, readMsgRead := conn.ReadMessage()
+				if readMsgRead != nil {
+					logger.Error().Err(readMsgRead).Msg("Read error")
+					return
+				}
+				writeMsgErr := conn.WriteMessage(ws.TextMessage, msg)
+				if writeMsgErr != nil {
+					logger.Error().Err(writeMsgErr).Msg("Write error")
+					return
+				}
+			}
+		}()
+	})
+
+	go http.ListenAndServe(":8080", nil)
+
+	return u
+}


### PR DESCRIPTION
# Unit Tests' startServer function

The Unit Tests for the Broker's Topics had a repetitive pattern when starting the HTTP server and upgrading it to a WebSocket, in order to simplify the code, a simple function is created, giving a **149** line reduction to the tests.

The function creates a WebSocket that logs to the function's custom logger with a custom extension for the HTTP URL.