### PR TITLE
[ethernet-view] Working State Orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 build
-.vscode
 
 # GOOGLE API KEY
 secret.json
@@ -7,5 +6,7 @@ secret.json
 # MacOS Files
 .DS_Store
 
-# JetBrains IDE
+# Code Editor
 .idea/
+.vscode/
+.prettierrc

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -161,6 +161,7 @@ func main() {
 	broker.AddTopic(connection_topic.UpdateName, connectionTopic)
 	broker.AddTopic(order_topic.SendName, orderTopic)
 	broker.AddTopic(logger_topic.EnableName, loggerTopic)
+	broker.AddTopic(logger_topic.ResponseName, loggerTopic)
 	broker.AddTopic(message_topic.UpdateName, messageTopic)
 
 	connections := make(chan *websocket.Client)

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -156,7 +156,7 @@ func main() {
 		boardIdToBoard[abstraction.BoardId(id)] = name
 	}
 	messageTopic := message_topic.NewUpdateTopic(boardIdToBoard)
-	stateOrderTopic := order_topic.NewState(idToBoard)
+	stateOrderTopic := order_topic.NewState(idToBoard, trace.Logger)
 
 	broker.AddTopic(data_topic.UpdateName, dataTopic)
 	broker.AddTopic(connection_topic.UpdateName, connectionTopic)

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -156,10 +156,12 @@ func main() {
 		boardIdToBoard[abstraction.BoardId(id)] = name
 	}
 	messageTopic := message_topic.NewUpdateTopic(boardIdToBoard)
+	stateOrderTopic := order_topic.NewState(idToBoard)
 
 	broker.AddTopic(data_topic.UpdateName, dataTopic)
 	broker.AddTopic(connection_topic.UpdateName, connectionTopic)
 	broker.AddTopic(order_topic.SendName, orderTopic)
+	broker.AddTopic(order_topic.StateName, stateOrderTopic)
 	broker.AddTopic(logger_topic.EnableName, loggerTopic)
 	broker.AddTopic(logger_topic.ResponseName, loggerTopic)
 	broker.AddTopic(message_topic.UpdateName, messageTopic)

--- a/backend/pkg/broker/topics/order/send.go
+++ b/backend/pkg/broker/topics/order/send.go
@@ -42,7 +42,7 @@ func (send *Send) ClientMessage(id websocket.ClientId, message *websocket.Messag
 	}
 }
 
-func (send *Send) handleOrder(id websocket.ClientId, message *websocket.Message) error {
+func (send *Send) handleOrder(_ websocket.ClientId, message *websocket.Message) error {
 	var order Order
 	err := json.Unmarshal(message.Payload, &order)
 	if err != nil {

--- a/backend/pkg/broker/topics/order/state.go
+++ b/backend/pkg/broker/topics/order/state.go
@@ -1,15 +1,41 @@
 package order
 
 import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/broker/topics"
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/transport/packet/order"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/websocket"
+	"github.com/google/uuid"
+	ws "github.com/gorilla/websocket"
 )
 
 const StateName abstraction.BrokerTopic = "order/stateOrders"
 
 type State struct {
-	pool *websocket.Pool
-	api  abstraction.BrokerAPI
+	enabledOrders map[string]map[abstraction.PacketId]struct{}
+	idToBoard     map[uint16]string
+	connectionMx  *sync.Mutex
+	subscribers   map[websocket.ClientId]struct{}
+	pool          *websocket.Pool
+	api           abstraction.BrokerAPI
+}
+
+func NewState(idToBoard map[uint16]string) *State {
+	enabled := make(map[string]map[abstraction.PacketId]struct{})
+	for _, board := range idToBoard {
+		enabled[board] = make(map[abstraction.PacketId]struct{})
+	}
+
+	return &State{
+		enabledOrders: enabled,
+		idToBoard:     idToBoard,
+		connectionMx:  new(sync.Mutex),
+		subscribers:   make(map[websocket.ClientId]struct{}),
+	}
 }
 
 func (state *State) Topic() abstraction.BrokerTopic {
@@ -17,11 +43,100 @@ func (state *State) Topic() abstraction.BrokerTopic {
 }
 
 func (state *State) Push(push abstraction.BrokerPush) error {
+	switch action := push.(type) {
+	case *StateAdd:
+		return state.addOrders(action.update)
+	case *StateRemove:
+		return state.removeOrders(action.update)
+	default:
+		fmt.Printf("unknown push type: %T", push)
+		return topics.ErrUnexpectedPush{Push: push}
+	}
+}
+
+func (state *State) addOrders(add *order.Add) error {
+	for _, addedOrder := range add.Orders() {
+		board, ok := state.idToBoard[uint16(addedOrder)]
+		if !ok {
+			fmt.Println("unrecoginzed id:", addedOrder)
+			continue
+		}
+
+		state.enabledOrders[board][addedOrder] = struct{}{}
+	}
+
+	return state.updateOrders()
+}
+
+func (state *State) removeOrders(remove *order.Remove) error {
+	for _, removedOrder := range remove.Orders() {
+		board, ok := state.idToBoard[uint16(removedOrder)]
+		if !ok {
+			fmt.Println("unrecoginzed id:", removedOrder)
+			continue
+		}
+
+		delete(state.enabledOrders[board], removedOrder)
+	}
+
+	return state.updateOrders()
+}
+
+func (state *State) updateOrders() error {
+	orderList := make(map[string][]abstraction.PacketId, len(state.enabledOrders))
+	for board, enabledOrders := range state.enabledOrders {
+		orderList[board] = make([]abstraction.PacketId, 0, len(enabledOrders))
+		for order := range enabledOrders {
+			orderList[board] = append(orderList[board], order)
+		}
+	}
+
+	payload, err := json.Marshal(orderList)
+	if err != nil {
+		return err
+	}
+
+	message := websocket.Message{
+		Topic:   StateName,
+		Payload: payload,
+	}
+
+	state.connectionMx.Lock()
+	defer state.connectionMx.Unlock()
+	flaged := make([]websocket.ClientId, 0, len(state.subscribers))
+	for id := range state.subscribers {
+		err := state.pool.Write(id, message)
+		if err != nil {
+			flaged = append(flaged, id)
+		}
+	}
+
+	for _, id := range flaged {
+		state.pool.Disconnect(id, ws.CloseInternalServerErr, "client disconnected")
+		delete(state.subscribers, id)
+		fmt.Printf("order/stateOrders unsubscribed %s\n", uuid.UUID(id).String())
+	}
+
 	return nil
 }
 
 func (state *State) Pull(request abstraction.BrokerRequest) (abstraction.BrokerResponse, error) {
 	return nil, nil
+}
+
+func (state *State) ClientMessage(id websocket.ClientId, message *websocket.Message) {
+	state.connectionMx.Lock()
+	defer state.connectionMx.Unlock()
+
+	switch message.Topic {
+	case StateName:
+		fmt.Printf("order/stateOrders subscribed %s\n", uuid.UUID(id).String())
+		state.subscribers[id] = struct{}{}
+	default:
+		state.pool.Disconnect(id, ws.CloseUnsupportedData, "unsupported topic")
+		delete(state.subscribers, id)
+		fmt.Printf("order/stateOrders unsubscribed %s\n", uuid.UUID(id).String())
+	}
 }
 
 func (state *State) SetPool(pool *websocket.Pool) {
@@ -30,4 +145,32 @@ func (state *State) SetPool(pool *websocket.Pool) {
 
 func (state *State) SetAPI(api abstraction.BrokerAPI) {
 	state.api = api
+}
+
+type StateAdd struct {
+	update *order.Add
+}
+
+func NewAdd(diff *order.Add) *StateAdd {
+	return &StateAdd{
+		update: diff,
+	}
+}
+
+func (add *StateAdd) Topic() abstraction.BrokerTopic {
+	return StateName
+}
+
+type StateRemove struct {
+	update *order.Remove
+}
+
+func NewRemove(diff *order.Remove) *StateRemove {
+	return &StateRemove{
+		update: diff,
+	}
+}
+
+func (remove *StateRemove) Topic() abstraction.BrokerTopic {
+	return StateName
 }

--- a/backend/pkg/vehicle/vehicle.go
+++ b/backend/pkg/vehicle/vehicle.go
@@ -3,9 +3,10 @@ package vehicle
 import (
 	"errors"
 	"fmt"
-	"github.com/HyperloopUPV-H8/h9-backend/pkg/boards"
 	"os"
 	"strings"
+
+	"github.com/HyperloopUPV-H8/h9-backend/pkg/boards"
 
 	"github.com/HyperloopUPV-H8/h9-backend/internal/update_factory"
 	"github.com/HyperloopUPV-H8/h9-backend/pkg/abstraction"
@@ -106,10 +107,17 @@ func (vehicle *Vehicle) Notification(notification abstraction.TransportNotificat
 		}
 
 	case *order.Add:
-		vehicle.trace.Warn().Msg("state order add not implemented")
-	case *order.Remove:
-		fmt.Fprintln(os.Stderr, "Received order.Remove packet, ignoring")
+		err := vehicle.broker.Push(order_topic.NewAdd(p))
 
+		if err != nil {
+			vehicle.trace.Error().Stack().Err(err).Msg("add state orders")
+		}
+	case *order.Remove:
+		err := vehicle.broker.Push(order_topic.NewRemove(p))
+
+		if err != nil {
+			vehicle.trace.Error().Stack().Err(err).Msg("remove state orders")
+		}
 	case *blcu_packet.Ack:
 		vehicle.boards[boards.BlcuId].Notify(abstraction.BoardNotification(
 			&boards.AckNotification{

--- a/backend/pkg/vehicle/vehicle.go
+++ b/backend/pkg/vehicle/vehicle.go
@@ -235,5 +235,6 @@ func (vehicle *Vehicle) ConnectionUpdate(target abstraction.TransportTarget, isC
 	vehicle.broker.Push(connection_topic.NewConnection(string(target), isConnected))
 	if isConnected {
 		vehicle.updateFactory.ClearPacketsFor(target)
+		vehicle.broker.Push(order_topic.NewStateClear(string(target)))
 	}
 }

--- a/common-front/lib/components/Orders/useOrders.ts
+++ b/common-front/lib/components/Orders/useOrders.ts
@@ -5,19 +5,21 @@ import {
     OrderDescription,
     OrderFieldDescription,
     useSubscribe,
-} from "../..";
+} from '../..';
 import {
     doesNumberOverflow,
     isNumberValid,
     isWithinRange,
-} from "../../numberValidation";
-import { useOrdersStore } from "../..";
+} from '../../numberValidation';
+import { useOrdersStore } from '../..';
 
 export function useOrders() {
-    const updateStateOrders = useOrdersStore((state) => state.updateStateOrders);
+    const updateStateOrders = useOrdersStore(
+        (state) => state.updateStateOrders
+    );
     const ordersBoards = useOrdersStore((state) => state.vehicleOrders.boards);
 
-    useSubscribe("order/stateOrders", (msg) => {
+    useSubscribe('order/stateOrders', (msg) => {
         updateStateOrders(msg);
     });
 
@@ -26,7 +28,7 @@ export function useOrders() {
 
 export function createFormFromOrder(
     order: OrderDescription
-): Omit<Form, "isValid"> {
+): Omit<Form, 'isValid'> {
     const fields = Object.values(order.fields).map((desc) => {
         return getField(desc);
     });
@@ -40,26 +42,26 @@ export function createFormFromOrder(
 
 function getField(desc: OrderFieldDescription): Field {
     switch (desc.kind) {
-        case "boolean":
+        case 'boolean':
             return {
                 id: desc.id,
                 name: desc.name,
-                type: "boolean",
+                type: 'boolean',
                 value: false,
             };
-        case "enum":
+        case 'enum':
             return {
                 id: desc.id,
                 name: desc.name,
-                type: "enum",
+                type: 'enum',
                 options: desc.options,
-                value: desc.options[0] ?? "Default",
+                value: desc.options[0] ?? 'Default',
             };
-        case "numeric":
+        case 'numeric':
             return {
                 id: desc.id,
                 name: desc.name,
-                type: "numeric",
+                type: 'numeric',
                 value: null,
                 placeholder: desc.type,
                 isValid: false,

--- a/common-front/lib/store/ordersStore.ts
+++ b/common-front/lib/store/ordersStore.ts
@@ -1,13 +1,13 @@
-import { StateCreator, StoreApi, UseBoundStore, create } from "zustand";
-import { BoardOrders, StateOrdersUpdate, VehicleOrders } from "..";
+import { StateCreator, StoreApi, UseBoundStore, create } from 'zustand';
+import { BoardOrders, StateOrdersUpdate, VehicleOrders } from '..';
 
 export interface OrdersStore {
-    vehicleOrders: VehicleOrders
-    setOrders: (vehicleOrders: VehicleOrders) => void
-    updateStateOrders: (stateOrdersUpdate: StateOrdersUpdate) => void
+    vehicleOrders: VehicleOrders;
+    setOrders: (vehicleOrders: VehicleOrders) => void;
+    updateStateOrders: (stateOrdersUpdate: StateOrdersUpdate) => void;
 }
 
-export const useOrdersStore= create<OrdersStore>((set, get) => ({
+export const useOrdersStore = create<OrdersStore>((set, get) => ({
     vehicleOrders: { boards: [] as BoardOrders[] },
 
     /**
@@ -15,32 +15,41 @@ export const useOrdersStore= create<OrdersStore>((set, get) => ({
      * @param {VehicleOrders} vehicleOrders
      */
     setOrders: (vehicleOrders: VehicleOrders) => {
-        set(state => ({
+        set((state) => ({
             ...state,
-            vehicleOrders: vehicleOrders
-        }))
+            vehicleOrders: vehicleOrders,
+        }));
     },
 
     /**
      * Reducer that updates orders to stateOrdersUpdate param.
      * It checks if the board vinculated with each order of stateOrdersUpdate exists.
      * If so, it is updated. If not exists, it ignores that order.
-     * @param {StateOrdersUpdate} stateOrdersUpdate 
+     * @param {StateOrdersUpdate} stateOrdersUpdate
      */
     updateStateOrders: (stateOrdersUpdate: StateOrdersUpdate) => {
-        const vehicleOrdersDraft = get().vehicleOrders;
-        Object.entries(stateOrdersUpdate).forEach(([name, ids]) => {
-            const index = get().vehicleOrders.boards.findIndex( (board) => board.name == name );
-            if (index == -1) return
-
-            vehicleOrdersDraft.boards[index].stateOrders.map(item => {
-                item.enabled = ids.includes(item.id);
-            })
-        })
-        set(state => ({
+        set((state) => ({
             ...state,
-            vehicleOrders: vehicleOrdersDraft
-        }))
+            vehicleOrders: {
+                ...state.vehicleOrders,
+                boards: state.vehicleOrders.boards.map((board) => {
+                    if (!(board.name in stateOrdersUpdate)) {
+                        return board;
+                    }
 
+                    return {
+                        ...board,
+                        stateOrders: board.stateOrders.map((desc) => {
+                            return {
+                                ...desc,
+                                enabled: stateOrdersUpdate[board.name].includes(
+                                    desc.id
+                                ),
+                            };
+                        }),
+                    };
+                }),
+            },
+        }));
     },
-}))
+}));

--- a/ethernet-view/src/components/OrdersContainer/Orders/Orders.tsx
+++ b/ethernet-view/src/components/OrdersContainer/Orders/Orders.tsx
@@ -1,9 +1,9 @@
-import styles from "./Orders.module.scss";
-import { BoardOrders, Button } from "common";
-import { OrderContext } from "./OrderContext";
-import { useSendOrder } from "../useSendOrder";
-import { BoardOrdersView } from "./BoardOrders/BoardOrders";
-import { useState } from "react";
+import styles from './Orders.module.scss';
+import { BoardOrders, Button } from 'common';
+import { OrderContext } from './OrderContext';
+import { useSendOrder } from '../useSendOrder';
+import { BoardOrdersView } from './BoardOrders/BoardOrders';
+import { useState } from 'react';
 
 type Props = {
     boards: BoardOrders[];
@@ -17,7 +17,8 @@ export const Orders = ({ boards }: Props) => {
         <OrderContext.Provider value={sendOrder}>
             <div className={styles.ordersWrapper}>
                 <div className={styles.stateOrdersToggle}>
-                    Always show state orders: {alwaysShowStateOrders}
+                    Always show state orders:{' '}
+                    {alwaysShowStateOrders ? 'true' : 'false'}
                     <Button
                         label="Toggle"
                         onClick={() =>

--- a/go.work
+++ b/go.work
@@ -3,4 +3,5 @@ go 1.21.3
 use (
 	./backend
 	./packet-sender
+	./state-order-tester
 )

--- a/state-order-tester/.gitignore
+++ b/state-order-tester/.gitignore
@@ -1,0 +1,1 @@
+state-order-tester

--- a/state-order-tester/go.mod
+++ b/state-order-tester/go.mod
@@ -1,0 +1,3 @@
+module github.com/HyperloopUPV-H8/state-order-tester
+
+go 1.21.3

--- a/state-order-tester/main.go
+++ b/state-order-tester/main.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"time"
+)
+
+var laddrFlag = flag.String("laddr", "127.0.0.3:50401", "local address for the connection")
+var raddrFlag = flag.String("raddr", "127.0.0.1:50500", "remote address for the connection")
+var stateOrderIDFlag = flag.Uint("id", 200, "id of the state order to toggle")
+var addStateOrderIDFlag = flag.Uint("add-id", 5, "message id to add state orders")
+var removeStateOrderIDFlag = flag.Uint("remove-id", 6, "message id to remove state orders")
+var delayFlag = flag.Duration("delay", 3*time.Second, "time between consecutive messages")
+var readBufferSizeFlag = flag.Int("read-buffer", 1460, "size of the read buffer")
+
+var byteOrder = binary.LittleEndian
+
+func main() {
+	flag.Parse()
+
+	conn, err := net.DialTCP("tcp", resolveTCPAddr(*laddrFlag), resolveTCPAddr(*raddrFlag))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	closeChan := make(chan error, 10)
+	go readConn(conn, closeChan)
+	go writeConn(conn, closeChan)
+
+	signalChan := make(chan os.Signal, 10)
+	signal.Notify(signalChan, os.Interrupt, os.Kill)
+
+	select {
+	case <-signalChan:
+		fmt.Println("close signal received")
+	case err := <-closeChan:
+		fmt.Fprintln(os.Stderr, err)
+	}
+
+	fmt.Println("closing...")
+}
+
+func resolveTCPAddr(address string) *net.TCPAddr {
+	resolved, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return resolved
+}
+
+func readConn(conn *net.TCPConn, closeChan chan<- error) {
+	buffer := make([]byte, *readBufferSizeFlag)
+	for {
+		n, err := conn.Read(buffer)
+		fmt.Println(">", string(buffer[:n]))
+		if err != nil {
+			closeChan <- err
+			return
+		}
+	}
+}
+
+func writeConn(conn *net.TCPConn, closeChan chan<- error) {
+	addPayload := generateAddPayload()
+	removePayload := generateRemovePayload()
+	for {
+		fmt.Println("< write add")
+		_, err := io.Copy(conn, bytes.NewReader(addPayload))
+		if err != nil {
+			closeChan <- err
+			return
+		}
+		<-time.After(*delayFlag)
+
+		fmt.Println("< write remove")
+		_, err = io.Copy(conn, bytes.NewReader(removePayload))
+		if err != nil {
+			closeChan <- err
+			return
+		}
+		<-time.After(*delayFlag)
+	}
+}
+
+func generateAddPayload() []byte {
+	payload := make([]byte, 6)
+	byteOrder.PutUint16(payload[0:2], uint16(*addStateOrderIDFlag))
+	byteOrder.PutUint16(payload[2:4], 1)
+	byteOrder.PutUint16(payload[4:6], uint16(*stateOrderIDFlag))
+	return payload
+}
+
+func generateRemovePayload() []byte {
+	payload := make([]byte, 6)
+	byteOrder.PutUint16(payload[0:2], uint16(*removeStateOrderIDFlag))
+	byteOrder.PutUint16(payload[2:4], 1)
+	byteOrder.PutUint16(payload[4:6], uint16(*stateOrderIDFlag))
+	return payload
+}

--- a/state-order-tester/main.go
+++ b/state-order-tester/main.go
@@ -74,21 +74,21 @@ func writeConn(conn *net.TCPConn, closeChan chan<- error) {
 	addPayload := generateAddPayload()
 	removePayload := generateRemovePayload()
 	for {
+		<-time.After(*delayFlag)
 		fmt.Println("< write add")
 		_, err := io.Copy(conn, bytes.NewReader(addPayload))
 		if err != nil {
 			closeChan <- err
 			return
 		}
-		<-time.After(*delayFlag)
 
+		<-time.After(*delayFlag)
 		fmt.Println("< write remove")
 		_, err = io.Copy(conn, bytes.NewReader(removePayload))
 		if err != nil {
 			closeChan <- err
 			return
 		}
-		<-time.After(*delayFlag)
 	}
 }
 


### PR DESCRIPTION
Added the half-implemented state order feature. State orders are orders that are enabled depending on the board state. When the board changes state it sends a diff of the state orders and those get updated on the fronted. When a board disconnects, the state orders are resetted for that board